### PR TITLE
v0.5.1: Setup-Script legt zusätzlich Skill-Symlink an

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,28 @@ Alle wesentlichen Änderungen am Skill und am Check-Katalog werden hier dokument
 Format orientiert sich an [Keep a Changelog](https://keepachangelog.com/de/1.1.0/).
 Versionierung: [Semantic Versioning](https://semver.org/lang/de/).
 
+## [v0.5.1] — 2026-04-26
+
+### Hinzugefügt — Skill-Auto-Discovery via Setup-Script
+
+`setup-slash-command.sh` legt nun **zusätzlich** einen Symlink von `~/.claude/skills/mcp-audit/` auf den Repo-Root an. Damit erkennt Claude Code Desktop den Skill automatisch und aktiviert ihn, wenn die Konversation auf das `description`-Feld in `SKILL.md` matcht (z.B. «ist mein Server sicher / production-ready», «Findings dokumentieren», «Audit», «Compliance-Check»).
+
+Der Slash-Command `/audit-mcp` bleibt parallel verfügbar — beide Mechanismen schliessen sich nicht aus.
+
+**Geändert:**
+- `setup-slash-command.sh` — neue `link_or_replace()`-Helper-Funktion; idempotent für Symlinks und Dateien/Verzeichnisse; legt jetzt beide Targets an
+- `README.md` — beschreibt beide Symlinks im Schnellstart
+
+**Anwender-Migration:**
+```bash
+cd mcp-audit-skill
+./setup-slash-command.sh   # legt nun zusätzlich den Skill-Symlink an
+```
+
+Bestehende Slash-Command-Symlinks bleiben unverändert; das Script meldet «Already linked» und ergänzt nur den fehlenden Skill-Symlink.
+
+---
+
 ## [v0.5.0] — 2026-04-26
 
 ### Hinzugefügt — Cloud-Modus für Slash-Command (WebFetch-Fallback)

--- a/README.md
+++ b/README.md
@@ -24,7 +24,11 @@ cd mcp-audit-skill
 ./setup-slash-command.sh
 ```
 
-Das Setup-Script symlinkt `.claude/commands/audit-mcp.md` nach `~/.claude/commands/`, damit `/audit-mcp` global in jeder Claude-Code-Session verfügbar ist. Optional kannst du `MCP_AUDIT_SKILL_PATH` in deiner Shell-RC setzen, damit der Command den Skill-Pfad nicht jedes Mal erfragen muss.
+Das Setup-Script symlinkt zwei Dinge:
+- `.claude/commands/audit-mcp.md` → `~/.claude/commands/audit-mcp.md` — damit `/audit-mcp` global als Slash-Command verfügbar ist
+- den Repo-Root → `~/.claude/skills/mcp-audit/` — damit Claude Code Desktop den Skill **automatisch** aktiviert, wenn der User informell nach einem Audit fragt («ist mein Server gut gebaut?», «Findings dokumentieren», etc.)
+
+Optional kannst du `MCP_AUDIT_SKILL_PATH` in deiner Shell-RC setzen, damit der Command den Skill-Pfad nicht jedes Mal erfragen muss.
 
 **Cloud-Modus (seit v0.5):** Wenn kein lokaler Klon vorhanden ist (z.B. Claude Code on the web oder restriktive Sandbox), lädt der Command Manifest, Check-Files und Templates automatisch via `WebFetch` aus `raw.githubusercontent.com/malkreide/mcp-audit-skill/main`. Kein Setup nötig — `/audit-mcp <repo>` funktioniert direkt, sofern der Slash-Command-File im aktuellen Workspace verfügbar ist (z.B. via `.claude/commands/audit-mcp.md` im Target-Repo oder global hinterlegt).
 
@@ -119,7 +123,7 @@ Details siehe [`SKILL.md`](./SKILL.md).
 
 ## Status
 
-**Version:** v0.5.0 — Cloud-Modus für Slash-Command via WebFetch-Fallback
+**Version:** v0.5.1 — Skill-Auto-Discovery via Setup-Script (Cloud-Modus seit v0.5.0)
 
 **Vollständigkeit:**
 - ✅ Methodik (`SKILL.md`)

--- a/setup-slash-command.sh
+++ b/setup-slash-command.sh
@@ -1,59 +1,90 @@
 #!/usr/bin/env bash
 #
-# setup-slash-command.sh — Installs /audit-mcp slash command for Claude Code
+# setup-slash-command.sh — Installs /audit-mcp slash command and mcp-audit
+# skill for Claude Code (CLI and Desktop).
 #
 # Usage:
 #   ./setup-slash-command.sh
 #
 # What it does:
 #   1. Locates this script's directory (the skill repo root)
-#   2. Creates ~/.claude/commands/ if missing
-#   3. Symlinks .claude/commands/audit-mcp.md to ~/.claude/commands/audit-mcp.md
+#   2. Symlinks .claude/commands/audit-mcp.md to ~/.claude/commands/audit-mcp.md
+#      (slash-command available globally in any Claude Code session)
+#   3. Symlinks the repo root to ~/.claude/skills/mcp-audit/
+#      (auto-loads as a Skill in Claude Code Desktop when description matches)
 #   4. Sets MCP_AUDIT_SKILL_PATH hint in shell rc file (optional)
 #
-# After running this, /audit-mcp <repo-url> works in any Claude Code session.
+# After running this, both /audit-mcp <repo> (slash-command) and the
+# mcp-audit skill (auto-activated by Claude Code) are available.
 
 set -euo pipefail
 
 SKILL_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-SOURCE="$SKILL_DIR/.claude/commands/audit-mcp.md"
-TARGET_DIR="$HOME/.claude/commands"
-TARGET="$TARGET_DIR/audit-mcp.md"
 
-if [[ ! -f "$SOURCE" ]]; then
-  echo "Error: $SOURCE not found. Are you running this from the skill repo root?" >&2
+# link_or_replace SOURCE TARGET — idempotent symlink with safe handling of
+# pre-existing symlinks (matching or pointing elsewhere) and regular
+# files/directories at the target path.
+link_or_replace() {
+  local source=$1
+  local target=$2
+  local target_dir
+  target_dir="$(dirname "$target")"
+
+  mkdir -p "$target_dir"
+
+  if [[ -L "$target" ]]; then
+    local current_target
+    current_target=$(readlink "$target")
+    if [[ "$current_target" == "$source" ]]; then
+      echo "Already linked: $target -> $source"
+      return 0
+    fi
+    echo "Existing symlink points elsewhere ($current_target). Replacing."
+    ln -sfn "$source" "$target"
+    return 0
+  fi
+
+  if [[ -e "$target" ]]; then
+    echo "Warning: $target exists as a regular file/directory (not a symlink)."
+    read -p "Backup to $target.bak and replace with symlink? [y/N] " -n 1 -r
+    echo
+    if [[ $REPLY =~ ^[Yy]$ ]]; then
+      mv "$target" "$target.bak"
+      ln -sfn "$source" "$target"
+      echo "Old file/directory backed up to $target.bak"
+      return 0
+    fi
+    echo "Aborted for $target. No changes made."
+    return 1
+  fi
+
+  ln -sfn "$source" "$target"
+  echo "Linked: $target -> $source"
+}
+
+# 1. Slash-command: ~/.claude/commands/audit-mcp.md -> repo file
+COMMAND_SOURCE="$SKILL_DIR/.claude/commands/audit-mcp.md"
+COMMAND_TARGET="$HOME/.claude/commands/audit-mcp.md"
+
+if [[ ! -f "$COMMAND_SOURCE" ]]; then
+  echo "Error: $COMMAND_SOURCE not found. Are you running this from the skill repo root?" >&2
   exit 1
 fi
 
-mkdir -p "$TARGET_DIR"
+link_or_replace "$COMMAND_SOURCE" "$COMMAND_TARGET" || true
 
-if [[ -L "$TARGET" ]]; then
-  current_target=$(readlink "$TARGET")
-  if [[ "$current_target" == "$SOURCE" ]]; then
-    echo "Already linked: $TARGET -> $SOURCE"
-  else
-    echo "Existing symlink points elsewhere ($current_target). Replacing."
-    ln -sf "$SOURCE" "$TARGET"
-  fi
-elif [[ -f "$TARGET" ]]; then
-  echo "Warning: $TARGET exists as a regular file (not a symlink)."
-  read -p "Backup to $TARGET.bak and replace with symlink? [y/N] " -n 1 -r
-  echo
-  if [[ $REPLY =~ ^[Yy]$ ]]; then
-    mv "$TARGET" "$TARGET.bak"
-    ln -s "$SOURCE" "$TARGET"
-    echo "Old file backed up to $TARGET.bak"
-  else
-    echo "Aborted. No changes made."
-    exit 1
-  fi
-else
-  ln -s "$SOURCE" "$TARGET"
-  echo "Linked: $TARGET -> $SOURCE"
+# 2. Skill: ~/.claude/skills/mcp-audit -> repo root
+SKILL_TARGET="$HOME/.claude/skills/mcp-audit"
+
+if [[ ! -f "$SKILL_DIR/SKILL.md" ]]; then
+  echo "Error: $SKILL_DIR/SKILL.md not found. Are you running this from the skill repo root?" >&2
+  exit 1
 fi
 
+link_or_replace "$SKILL_DIR" "$SKILL_TARGET" || true
+
 echo
-echo "✓ /audit-mcp slash command is now globally available in Claude Code."
+echo "✓ /audit-mcp slash command and mcp-audit skill are now globally available in Claude Code."
 echo
 echo "Optional: add MCP_AUDIT_SKILL_PATH to your shell rc to skip path-prompts:"
 echo "  echo 'export MCP_AUDIT_SKILL_PATH=\"$SKILL_DIR\"' >> ~/.bashrc"
@@ -65,3 +96,6 @@ echo "  cd <any-mcp-server-repo>"
 echo "  claude"
 echo "  > /audit-mcp ."
 echo "  > /audit-mcp https://github.com/malkreide/zh-education-mcp"
+echo
+echo "Or let Claude auto-load the skill when you ask informally:"
+echo "  > Audit den Server in diesem Repo gegen die Best Practices."


### PR DESCRIPTION
## Summary

- `setup-slash-command.sh` legt jetzt **zusätzlich** einen Symlink von `~/.claude/skills/mcp-audit/` auf den Repo-Root an. Damit erkennt Claude Code Desktop den Skill automatisch und aktiviert ihn, wenn die Konversation auf das `description`-Feld in `SKILL.md` matcht.
- Slash-Command-Symlink bleibt parallel verfügbar — beide Mechanismen schliessen sich nicht aus.
- Neue `link_or_replace()`-Helper-Funktion: idempotent für Symlinks (matching/wrong target) und reguläre Files/Directories (mit Backup-Prompt).

## Verifikation

Smoke-Test in einem Fake-`$HOME`:

```
Linked: /tmp/fakehome/.claude/commands/audit-mcp.md -> .../audit-mcp.md
Linked: /tmp/fakehome/.claude/skills/mcp-audit -> .../mcp-audit-skill
```

Zweiter Run idempotent:

```
Already linked: .../audit-mcp.md
Already linked: .../mcp-audit
```

## Test plan

- [ ] Frischer User: `./setup-slash-command.sh` legt beide Symlinks an, keine Prompts
- [ ] Bestehender User mit altem Slash-Command-Symlink: Script meldet «Already linked» für Command, ergänzt nur den fehlenden Skill-Symlink
- [ ] User mit pre-existing `~/.claude/skills/mcp-audit/`-Verzeichnis: Script fragt nach Backup, default = nein
- [ ] In Claude Code Desktop: Skill-Auto-Activation testen (z.B. «ist mein Server production-ready?»)
- [ ] Slash-Command `/audit-mcp .` weiterhin funktional

---
_Generated by [Claude Code](https://claude.ai/code/session_01DX5XiNXuL3zkmjXTs1dpMm)_