### PR TITLE
Findings-persistence aggregator: single source of truth (closes #8, #9)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ Versionierung: [Semantic Versioning](https://semver.org/lang/de/).
 
 ## [Unreleased]
 
+### Hinzugefügt — Findings-Persistenz-Aggregator (Single-Source-of-Truth)
+
+Behebt Issues #8 (Findings-Persistenz) und #9 (Status-Drift). Im ersten Audit (`srgssr-mcp`, 2026-04-30) berichteten drei Stages drei verschiedene Zahlen für dieselben Daten — Step 5 sagte 15 Findings, Step 6 sagte 6, auf Disk waren 6. Strukturelle Lösung:
+
+- **`tools/aggregate_results.py`** — Single-Source-of-Truth-Aggregator. Liest `verification-results.json`, produziert `summary.json` mit canonical Counts, validiert `findings/` gegen `expected_ids`. CLI: `aggregate`, `expected-findings`, `validate`.
+- **Findings-Persistenz-Policies** — explizite Wahl zwischen `fail-or-partial` (Default), `fail-only`, `needs-attention`. Policy wird in `summary.json` persistiert.
+- **Schema-Validierung** — `CheckResult` rejectet ungültige Status- und Severity-Werte beim Laden.
+- **Validation-Gate** — `validate <audit_dir>` exitet mit Code 1 wenn `findings/*.md` nicht zu `expected_ids` passt. Pflicht-Schritt vor Audit-Abschluss.
+- **`docs/verification-results-schema.md`** — formale Spec der Datenkontrakte zwischen Step 4/5/6.
+- **`tests/test_aggregate_results.py`** (32 Cases) — inkl. Regression-Test, der den exakten srgssr-Bug reproduziert (nur 6 von 15 Findings persistiert) und vom Validator gefangen wird.
+- **SKILL.md Step 5/6-Update** — verbindliche Spec, dass alle Counts aus `summary.json` zu lesen sind, nie neu zu berechnen.
+
 ### Hinzugefügt — Reproduzierbarkeits-Hardening nach erstem PowerShell-Audit
 
 Nach dem ersten realen Audit-Lauf (`srgssr-mcp`, 2026-04-30) auf Windows/Git Bash zeigten sich Reproduzierbarkeits- und Cross-Platform-Lücken. Behoben:
@@ -29,8 +41,6 @@ Der Evaluator hat 9 Catalog-Bugs gefunden, in denen `deployment` (Liste) gegen e
 - Audit-Findings-Sub-DB unter dem Notion-Audit-Tracker
 - Parallelism in `audit-portfolio.sh` via `xargs -P`
 - Profile-Override-Layer (lokale Datei merged mit Tracker-Werten beim `pull`)
-- Aggregator-Tool als Single-Source-of-Truth für Status-Counts (Issue #9)
-- Findings-Persistenz-Spec (Issue #8)
 - `write_access` vs. `write_capable`-Schema-Migration (Issue #13)
 
 ---

--- a/SKILL.md
+++ b/SKILL.md
@@ -286,6 +286,35 @@ Sonst: `partial` (wenn 50%+ erfüllt) oder `fail`.
 
 **Ziel:** Pro fehlgeschlagenem Check ein strukturiertes Finding erzeugen, das direkt in einen Remediation-Plan überführbar ist.
 
+### 5.0 Findings-Persistenz-Regel (verbindlich)
+
+Ein Finding-Document wird **genau dann** erzeugt, wenn der Check-Status in der **Findings-Policy** enthalten ist. Es gibt drei Policies, dokumentiert in [`tools/aggregate_results.py`](tools/aggregate_results.py):
+
+| Policy | Findings für Status | Wann verwenden |
+|---|---|---|
+| `fail-or-partial` (Default) | `fail` + `partial` | Standard-Audit, vollständige Remediation-Backlog |
+| `fail-only` | `fail` | Schnell-Audit, nur Showstopper |
+| `needs-attention` | `fail` + `partial` + `todo` | Pre-Production-Härtung, alles offene |
+
+Die Policy MUSS in jedem Audit-Run explizit gesetzt und in `summary.json` persistiert werden. **Vor Abschluss des Audits ist `tools/aggregate_results.py validate <audit_dir>` Pflicht** — sonst können die Findings-Counts in Step 5 und Step 6 auseinanderdriften (Real-World-Bug aus dem ersten Audit).
+
+```bash
+# 1. Verification-Results aus Step 4 in JSON serialisieren
+#    (Schema: siehe tools/aggregate_results.py docstring)
+# 2. Aggregieren — produziert summary.json als Single-Source-of-Truth
+python tools/aggregate_results.py aggregate \
+    audits/<run>/verification-results.json \
+    --policy fail-or-partial \
+    --out audits/<run>/summary.json
+
+# 3. Liste der zu schreibenden Findings ausgeben
+python tools/aggregate_results.py expected-findings \
+    audits/<run>/verification-results.json --policy fail-or-partial
+
+# 4. Nach dem Schreiben: Validation-Gate (hard fail bei Mismatch)
+python tools/aggregate_results.py validate audits/<run>/
+```
+
 ### 5.1 Finding-Template
 
 Verwendet `templates/finding.md`:
@@ -322,12 +351,17 @@ S (< 1d) | M (1-3d) | L (1-2w) | XL (>2w)
 
 ### 5.2 Findings-Anzahl zurück in Audit Tracker
 
-Nach Abschluss des Audits wird die `Findings`-Spalte in der Notion-Karte aktualisiert:
+Nach Abschluss des Audits wird die `Findings`-Spalte in der Notion-Karte aktualisiert. Der Wert MUSS aus `summary.json` gelesen werden, niemals neu gezählt:
+
+```bash
+# Korrekt: Single-Source-of-Truth
+total_findings=$(jq '.findings.expected_count' audits/<run>/summary.json)
+update_audit_tracker --server "$name" --findings "$total_findings" --status "Findings dokumentiert"
+```
 
 ```python
-# Pseudo-code für Tracker-Update
+# FALSCH: separate Re-Computation — riskiert Drift gegen Step 5/6
 total_findings = sum(1 for r in check_runs if r.status in ("fail", "partial"))
-update_audit_tracker(server=name, findings=total_findings, status="Findings dokumentiert")
 ```
 
 ### 5.3 Audit-Status-Transition
@@ -354,6 +388,19 @@ update_audit_tracker(server=name, findings=total_findings, status="Findings doku
 5. **Detail-Findings** (eines pro fehlgeschlagenem Check, vollständig)
 6. **Remediation-Plan** (Effort-Schätzung pro Finding, Vorschlag-Reihenfolge)
 7. **Audit-Metadata** (wer, wann, Skill-Version, Check-Katalog-Version)
+
+**Pflicht:** Alle Zahlen im Report (Status-Counts, Findings-Anzahl, Production-Ready-Flag, Blocking-Findings) MÜSSEN aus `summary.json` gelesen werden. Niemals direkt aus den `raw/`-Files oder über Re-Aggregation neu berechnen — sonst entsteht der Drift-Bug aus dem srgssr-Audit (Step 4 zeigte 8 PASS, Final Report zeigte 13 PASS).
+
+```bash
+# Status-Counts im Report
+jq '.totals.by_status' audits/<run>/summary.json
+
+# Production-Ready
+jq '.production_ready' audits/<run>/summary.json
+
+# Blocking-Findings (failing critical/high)
+jq -r '.blocking_findings[]' audits/<run>/summary.json
+```
 
 ### 6.2 Sprache und Adressaten
 

--- a/docs/verification-results-schema.md
+++ b/docs/verification-results-schema.md
@@ -1,0 +1,189 @@
+# Verification Results Schema & Findings Persistence Spec
+
+This document defines the canonical contract between Step 4 (check execution), Step 5 (finding persistence), and Step 6 (report generation). Reference implementation: [`tools/aggregate_results.py`](../tools/aggregate_results.py). Conformance test: [`tests/test_aggregate_results.py`](../tests/test_aggregate_results.py).
+
+## Why this exists
+
+In the first real audit run (`srgssr-mcp`, 2026-04-30), three different stages of the same audit reported three different counts:
+
+| Stage | Findings count | Reason |
+|---|---|---|
+| Step 5 announcement | 15 | counted FAIL + PARTIAL |
+| Step 6 final report | 6 | counted FAIL only |
+| Files on disk under `findings/` | 6 | only FAIL was persisted |
+
+Three independent computations against the same data → three different numbers. The skill's credibility depends on this never recurring. The fix is structural: a single canonical aggregator that all downstream stages MUST consume.
+
+## Schema: `verification-results.json`
+
+Step 4 produces this file. It is the **only** ground truth.
+
+```json
+{
+  "audit_meta": {
+    "server_name": "srgssr-mcp",
+    "audit_date": "2026-04-30",
+    "skill_version": "0.8.x",
+    "catalog_version": "2026-04",
+    "applies_when_dsl_version": "1.0",
+    "policy": "fail-or-partial"
+  },
+  "results": {
+    "ARCH-001": {
+      "status": "pass",
+      "category": "ARCH",
+      "severity": "medium",
+      "evidence": ["src/server.py:42 — tool decorator with name=\"getX\""],
+      "gaps": []
+    },
+    "OPS-001": {
+      "status": "fail",
+      "category": "OPS",
+      "severity": "high",
+      "evidence": [],
+      "gaps": ["No tests/ directory", "No pytest in pyproject.toml"]
+    }
+  }
+}
+```
+
+### Status enum
+
+| Value | Meaning | Findings-doc by default? |
+|---|---|---|
+| `pass` | Check fully satisfied | No |
+| `fail` | Check failed; concrete remediation needed | **Yes** |
+| `partial` | Check 50%+ but not fully satisfied | **Yes** |
+| `todo` | Manual review required, no judgment yet | No |
+| `n/a` | Not applicable to this profile (rare; usually omitted) | No |
+
+### Severity enum
+
+`critical`, `high`, `medium`, `low`. Mirrors the check-file frontmatter.
+
+### Required fields per result
+
+- `status` — one of the values above
+- `category` — `ARCH`, `SEC`, `CH`, `HITL`, `OBS`, `OPS`, `SCALE`, `SDK`
+- `severity` — one of the values above
+- `evidence` (list of strings, may be empty)
+- `gaps` (list of strings, may be empty)
+
+## Findings-Persistence Policies
+
+A policy maps statuses to "should this produce a finding doc?". Three are supported:
+
+| Policy | Statuses that produce a finding doc |
+|---|---|
+| `fail-or-partial` (default) | `fail`, `partial` |
+| `fail-only` | `fail` |
+| `needs-attention` | `fail`, `partial`, `todo` |
+
+The chosen policy MUST be:
+1. Set explicitly at the start of Step 5.
+2. Persisted in `summary.json` so the report can reference it.
+3. Identical between Step 5 (when finding docs are written) and Step 6 (when counts are reported).
+
+## Aggregation: `summary.json`
+
+The aggregator (`tools/aggregate_results.py aggregate`) consumes verification-results.json and produces summary.json. Shape:
+
+```json
+{
+  "audit_meta": { "...": "..." },
+  "totals": {
+    "checks_evaluated": 33,
+    "applicable": 26,
+    "by_status": {
+      "pass": 8, "fail": 6, "partial": 9, "todo": 3, "n/a": 7
+    },
+    "by_severity_among_findings": {
+      "critical": 0, "high": 1, "medium": 14, "low": 0
+    },
+    "by_category": {
+      "ARCH": {"pass": 5, "fail": 3, "partial": 5, "todo": 0, "n/a": 0},
+      "...": "..."
+    }
+  },
+  "findings": {
+    "policy": "fail-or-partial",
+    "policy_statuses": ["fail", "partial"],
+    "expected_count": 15,
+    "expected_ids": ["ARCH-001", "ARCH-002", "...", "OPS-003"],
+    "details": [
+      {
+        "check_id": "OPS-001",
+        "category": "OPS",
+        "severity": "high",
+        "status": "fail"
+      }
+    ]
+  },
+  "production_ready": false,
+  "blocking_findings": ["OPS-001"]
+}
+```
+
+### Production-readiness rule
+
+`production_ready` is `false` if there is at least one `fail` with severity in `{critical, high}`. PARTIAL high/critical does **not** block — partial means progress, fail means no progress.
+
+## Validation Gate (mandatory)
+
+Before the audit is considered complete, this gate MUST pass:
+
+```bash
+python tools/aggregate_results.py validate audits/<run>/
+```
+
+It compares the set of expected check-IDs from `summary.json` against the on-disk filenames in `findings/`. The filename convention is `<CHECK-ID>-<slug>.md`; the validator extracts the prefix and matches against the expected set.
+
+Outcomes:
+- **Consistent** — all expected findings are persisted, no extras → exit 0
+- **Missing** — some expected findings have no file on disk → exit 1
+- **Unexpected** — files exist for checks that shouldn't have findings → exit 1
+
+The first audit's bug would have been caught immediately:
+
+```text
+Findings on disk don't match summary.expected_ids:
+  missing=['ARCH-001', 'ARCH-003', 'ARCH-004', ..., 'OPS-003'],  ← 9 missing
+  unexpected=[]
+```
+
+## Filename Convention
+
+```
+findings/
+  ARCH-001-tool-naming-convention.md
+  ARCH-002-tool-descriptions.md
+  OPS-001-test-strategy.md
+  SEC-021-egress-allowlist.md
+```
+
+Format: `<CHECK-ID>-<slug>.md`. The slug is human-readable kebab-case.
+
+## CLI summary
+
+```bash
+# Aggregate (Step 5 entry point)
+python tools/aggregate_results.py aggregate verification-results.json \
+    --policy fail-or-partial \
+    --out summary.json
+
+# List expected findings (used by Step 5 to know what to write)
+python tools/aggregate_results.py expected-findings verification-results.json \
+    --policy fail-or-partial
+
+# Validate (Step 5 exit gate, Step 6 entry gate)
+python tools/aggregate_results.py validate audits/<run>/
+```
+
+## Stages that MUST consume summary.json
+
+- **Step 5** — only writes finding docs for `expected_ids`
+- **Step 6** — all counts in audit-report.md
+- **Notion-Sync (`audit-notion-sync.py push`)** — `findings`, `production_ready`, `blocking_findings`
+- **Portfolio dashboards** — comparable counts across servers
+
+If any stage recomputes counts independently, that is a bug. File an issue.

--- a/tests/test_aggregate_results.py
+++ b/tests/test_aggregate_results.py
@@ -1,0 +1,408 @@
+# -*- coding: utf-8 -*-
+"""Tests for tools/aggregate_results.py — single source of truth for audit
+verification results.
+
+The fixtures below recreate the exact inconsistency observed in the first
+real audit (srgssr-mcp, 2026-04-30): step 4 reported one set of counts,
+step 5 announced 15 finding docs, step 6 reported 6, and the on-disk
+findings/ dir held only 6. The tests lock in deterministic behaviour so
+that bug cannot recur.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from tools.aggregate_results import (
+    AggregationError,
+    CheckResult,
+    POLICIES,
+    VerificationResults,
+    ValidationError,
+    aggregate,
+    extract_check_id_from_finding_filename,
+    validate_findings_persistence,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def srgssr_results() -> VerificationResults:
+    """Reconstructs the srgssr-mcp audit verification results.
+
+    Numbers come from the published audit report:
+      PASS=8, FAIL=6, PARTIAL=9, TODO=3, N/A=7   → 33 applicable
+    Plus a few representative IDs per status for assertions.
+    """
+    rows = []
+    rows += [("ARCH-009", "pass", "ARCH", "medium")] * 8  # PASS group
+    rows += [
+        ("ARCH-002", "fail", "ARCH", "medium"),
+        ("ARCH-008", "fail", "ARCH", "medium"),
+        ("ARCH-012", "fail", "ARCH", "medium"),
+        ("SEC-021", "fail", "SEC", "medium"),
+        ("OBS-003", "fail", "OBS", "medium"),
+        ("OPS-001", "fail", "OPS", "high"),
+    ]
+    rows += [
+        ("ARCH-001", "partial", "ARCH", "medium"),
+        ("ARCH-003", "partial", "ARCH", "medium"),
+        ("ARCH-004", "partial", "ARCH", "medium"),
+        ("ARCH-007", "partial", "ARCH", "medium"),
+        ("ARCH-011", "partial", "ARCH", "medium"),
+        ("SEC-004", "partial", "SEC", "medium"),
+        ("SEC-018", "partial", "SEC", "medium"),
+        ("OPS-002", "partial", "OPS", "medium"),
+        ("OPS-003", "partial", "OPS", "medium"),
+    ]
+    rows += [
+        ("CH-007", "todo", "CH", "low"),
+        ("HITL-002", "todo", "HITL", "medium"),
+        ("SDK-005", "todo", "SDK", "low"),
+    ]
+    rows += [("SEC-099", "n/a", "SEC", "medium")] * 7  # N/A group
+
+    # Synthetic unique IDs for the duplicates so assertions still work
+    # — replace placeholder IDs with cid-N so the result dict has unique keys.
+    results: dict[str, CheckResult] = {}
+    counters: dict[str, int] = {}
+    for base_id, status, category, severity in rows:
+        n = counters.get(base_id, 0)
+        counters[base_id] = n + 1
+        cid = base_id if n == 0 else f"{base_id}-DUP{n}"
+        results[cid] = CheckResult(
+            check_id=cid,
+            status=status,
+            category=category,
+            severity=severity,
+        )
+    return VerificationResults(
+        audit_meta={
+            "server_name": "srgssr-mcp",
+            "audit_date": "2026-04-30",
+            "skill_version": "test",
+            "catalog_version": "2026-04",
+        },
+        results=results,
+    )
+
+
+@pytest.fixture
+def minimal_results() -> VerificationResults:
+    """Hand-built tiny fixture for arithmetic verification."""
+    return VerificationResults(
+        audit_meta={"server_name": "tiny", "audit_date": "2026-05-02"},
+        results={
+            "ARCH-001": CheckResult("ARCH-001", "pass", "ARCH", "medium"),
+            "SEC-001": CheckResult("SEC-001", "fail", "SEC", "critical"),
+            "OBS-001": CheckResult("OBS-001", "partial", "OBS", "high"),
+            "OPS-001": CheckResult("OPS-001", "todo", "OPS", "low"),
+            "CH-001": CheckResult("CH-001", "n/a", "CH", "medium"),
+        },
+    )
+
+
+# ---------------------------------------------------------------------------
+# Schema validation
+# ---------------------------------------------------------------------------
+
+class TestSchema:
+    def test_valid_result(self):
+        r = CheckResult("X-001", "pass", "ARCH", "medium")
+        assert r.status == "pass"
+
+    def test_invalid_status_rejected(self):
+        with pytest.raises(AggregationError, match="invalid status"):
+            CheckResult("X-001", "MAYBE", "ARCH", "medium")
+
+    def test_invalid_severity_rejected(self):
+        with pytest.raises(AggregationError, match="invalid severity"):
+            CheckResult("X-001", "pass", "ARCH", "showstopper")
+
+    def test_from_dict_round_trip(self, minimal_results):
+        as_dict = {
+            "audit_meta": minimal_results.audit_meta,
+            "results": {
+                cid: {
+                    "status": r.status,
+                    "category": r.category,
+                    "severity": r.severity,
+                    "evidence": r.evidence,
+                    "gaps": r.gaps,
+                }
+                for cid, r in minimal_results.results.items()
+            },
+        }
+        round_tripped = VerificationResults.from_dict(as_dict)
+        assert round_tripped.results.keys() == minimal_results.results.keys()
+
+    def test_from_dict_rejects_non_dict(self):
+        with pytest.raises(AggregationError):
+            VerificationResults.from_dict([])  # type: ignore[arg-type]
+
+    def test_from_dict_requires_results(self):
+        with pytest.raises(AggregationError, match="Missing 'results'"):
+            VerificationResults.from_dict({"audit_meta": {}})
+
+
+# ---------------------------------------------------------------------------
+# Aggregation arithmetic — locks in the regression
+# ---------------------------------------------------------------------------
+
+class TestAggregateMinimal:
+    def test_default_policy_counts(self, minimal_results):
+        s = aggregate(minimal_results)
+        # 5 total, 4 applicable (excluding n/a)
+        assert s["totals"]["checks_evaluated"] == 5
+        assert s["totals"]["applicable"] == 4
+        assert s["totals"]["by_status"]["pass"] == 1
+        assert s["totals"]["by_status"]["fail"] == 1
+        assert s["totals"]["by_status"]["partial"] == 1
+        assert s["totals"]["by_status"]["todo"] == 1
+        assert s["totals"]["by_status"]["n/a"] == 1
+
+    def test_default_policy_findings(self, minimal_results):
+        s = aggregate(minimal_results)
+        # fail-or-partial → SEC-001 (fail) + OBS-001 (partial) = 2
+        assert s["findings"]["expected_count"] == 2
+        assert set(s["findings"]["expected_ids"]) == {"SEC-001", "OBS-001"}
+
+    def test_fail_only_policy(self, minimal_results):
+        s = aggregate(minimal_results, policy="fail-only")
+        assert s["findings"]["expected_count"] == 1
+        assert s["findings"]["expected_ids"] == ["SEC-001"]
+
+    def test_needs_attention_policy(self, minimal_results):
+        s = aggregate(minimal_results, policy="needs-attention")
+        # FAIL + PARTIAL + TODO = 3
+        assert s["findings"]["expected_count"] == 3
+        assert set(s["findings"]["expected_ids"]) == {
+            "SEC-001", "OBS-001", "OPS-001",
+        }
+
+    def test_blocking_findings_critical_or_high(self, minimal_results):
+        s = aggregate(minimal_results)
+        # SEC-001 is fail+critical → blocks production.
+        # OBS-001 is partial+high → does NOT block (only fail+blocking blocks).
+        assert s["production_ready"] is False
+        assert s["blocking_findings"] == ["SEC-001"]
+
+    def test_unknown_policy_rejected(self, minimal_results):
+        with pytest.raises(AggregationError, match="Unknown findings policy"):
+            aggregate(minimal_results, policy="invent-it")
+
+
+class TestAggregateSrgssrRegression:
+    """The srgssr audit is the regression baseline — its counts MUST be
+    deterministic regardless of policy.
+    """
+
+    def test_total_status_counts_match_audit_report(self, srgssr_results):
+        s = aggregate(srgssr_results)
+        bs = s["totals"]["by_status"]
+        assert bs["pass"] == 8
+        assert bs["fail"] == 6
+        assert bs["partial"] == 9
+        assert bs["todo"] == 3
+        assert bs["n/a"] == 7
+        # Sum equals applicable + n/a
+        assert sum(bs.values()) == 33
+
+    def test_applicable_count_excludes_na(self, srgssr_results):
+        s = aggregate(srgssr_results)
+        # 8 + 6 + 9 + 3 = 26 applicable (the audit report's 33 figure
+        # included n/a; here we treat 'applicable' as 'evaluated and
+        # judged' — n/a means not-judged-because-not-relevant).
+        assert s["totals"]["applicable"] == 26
+
+    def test_findings_count_default_policy(self, srgssr_results):
+        s = aggregate(srgssr_results)
+        # Default = fail-or-partial → 6 + 9 = 15
+        # This is the number that Step 5 announced. The bug was that
+        # step 6 reported only 6 (fail-only) — the policy must be
+        # explicit and consistent across all steps.
+        assert s["findings"]["expected_count"] == 15
+
+    def test_findings_count_fail_only(self, srgssr_results):
+        s = aggregate(srgssr_results, policy="fail-only")
+        # The 6 number from Step 6 of the original audit.
+        assert s["findings"]["expected_count"] == 6
+
+    def test_blocking_finding_is_ops_001(self, srgssr_results):
+        s = aggregate(srgssr_results)
+        assert s["production_ready"] is False
+        assert "OPS-001" in s["blocking_findings"]
+        # No critical-severity fails in srgssr → only OPS-001 (high) blocks.
+        assert s["blocking_findings"] == ["OPS-001"]
+
+    def test_summary_totals_sum_to_evaluated(self, srgssr_results):
+        s = aggregate(srgssr_results)
+        bs = s["totals"]["by_status"]
+        assert sum(bs.values()) == s["totals"]["checks_evaluated"]
+
+
+# ---------------------------------------------------------------------------
+# Validation against on-disk findings/
+# ---------------------------------------------------------------------------
+
+class TestValidationAgainstDisk:
+    def _write_finding(self, dir: Path, check_id: str, slug: str = "test") -> None:
+        dir.mkdir(parents=True, exist_ok=True)
+        (dir / f"{check_id}-{slug}.md").write_text(
+            f"# {check_id}\nbody\n", encoding="utf-8"
+        )
+
+    def test_consistent_set(self, tmp_path, minimal_results):
+        s = aggregate(minimal_results)
+        for cid in s["findings"]["expected_ids"]:
+            self._write_finding(tmp_path, cid)
+        report = validate_findings_persistence(s, tmp_path)
+        assert report["consistent"] is True
+        assert report["missing"] == []
+        assert report["unexpected"] == []
+
+    def test_missing_finding_raises(self, tmp_path, minimal_results):
+        s = aggregate(minimal_results)
+        # write only one of the two expected
+        self._write_finding(tmp_path, "SEC-001")
+        with pytest.raises(ValidationError, match="missing=\\['OBS-001'\\]"):
+            validate_findings_persistence(s, tmp_path)
+
+    def test_unexpected_finding_raises(self, tmp_path, minimal_results):
+        s = aggregate(minimal_results)
+        for cid in s["findings"]["expected_ids"]:
+            self._write_finding(tmp_path, cid)
+        # extra finding for a check that should not have one
+        self._write_finding(tmp_path, "ARCH-001")
+        with pytest.raises(ValidationError, match="unexpected"):
+            validate_findings_persistence(s, tmp_path)
+
+    def test_empty_findings_dir(self, tmp_path, minimal_results):
+        s = aggregate(minimal_results)
+        # tmp_path exists but is empty
+        with pytest.raises(ValidationError):
+            validate_findings_persistence(s, tmp_path)
+
+    def test_missing_findings_dir(self, tmp_path, minimal_results):
+        s = aggregate(minimal_results)
+        with pytest.raises(ValidationError):
+            validate_findings_persistence(s, tmp_path / "does-not-exist")
+
+    def test_srgssr_default_policy_validation(self, tmp_path, srgssr_results):
+        s = aggregate(srgssr_results)
+        # Persist all 15 expected findings — should validate clean.
+        for cid in s["findings"]["expected_ids"]:
+            self._write_finding(tmp_path, cid)
+        report = validate_findings_persistence(s, tmp_path)
+        assert report["consistent"] is True
+        assert report["expected_count"] == 15
+        assert report["found_count"] == 15
+
+    def test_srgssr_original_audit_bug_is_caught(self, tmp_path, srgssr_results):
+        """In the original audit, only 6 of 15 findings were persisted to
+        disk. The validator must fail loudly on that mismatch.
+        """
+        s = aggregate(srgssr_results)
+        # Persist only the 6 FAIL findings — replicating the original bug.
+        for cid in s["findings"]["expected_ids"]:
+            r = srgssr_results.results[cid]
+            if r.status == "fail":
+                self._write_finding(tmp_path, cid)
+        with pytest.raises(ValidationError) as exc:
+            validate_findings_persistence(s, tmp_path)
+        # The 9 PARTIAL findings should be reported as missing.
+        assert "missing=" in str(exc.value)
+
+
+class TestFilenameParser:
+    def test_arch_id_extracted(self):
+        assert extract_check_id_from_finding_filename(
+            Path("ARCH-001-tool-naming.md")
+        ) == "ARCH-001"
+
+    def test_multi_segment_check_id(self):
+        assert extract_check_id_from_finding_filename(
+            Path("SEC-021-egress-allowlist.md")
+        ) == "SEC-021"
+
+    def test_no_id_in_filename(self):
+        assert extract_check_id_from_finding_filename(
+            Path("README.md")
+        ) is None
+
+
+# ---------------------------------------------------------------------------
+# CLI smoke tests
+# ---------------------------------------------------------------------------
+
+class TestCli:
+    def _write_results(self, path: Path, vr: VerificationResults) -> None:
+        as_dict = {
+            "audit_meta": vr.audit_meta,
+            "results": {
+                cid: {
+                    "status": r.status,
+                    "category": r.category,
+                    "severity": r.severity,
+                    "evidence": r.evidence,
+                    "gaps": r.gaps,
+                }
+                for cid, r in vr.results.items()
+            },
+        }
+        path.write_text(json.dumps(as_dict, indent=2), encoding="utf-8")
+
+    def test_aggregate_to_file(self, tmp_path, minimal_results):
+        from tools.aggregate_results import main
+        results_path = tmp_path / "results.json"
+        out_path = tmp_path / "summary.json"
+        self._write_results(results_path, minimal_results)
+        rc = main(["aggregate", str(results_path), "--out", str(out_path)])
+        assert rc == 0
+        assert out_path.exists()
+        summary = json.loads(out_path.read_text(encoding="utf-8"))
+        assert summary["findings"]["expected_count"] == 2
+
+    def test_validate_command_passes(self, tmp_path, minimal_results, capsys):
+        from tools.aggregate_results import main
+        audit_dir = tmp_path / "audit"
+        findings_dir = audit_dir / "findings"
+        findings_dir.mkdir(parents=True)
+        results_path = audit_dir / "verification-results.json"
+        summary_path = audit_dir / "summary.json"
+        self._write_results(results_path, minimal_results)
+        # Aggregate first
+        rc = main(["aggregate", str(results_path), "--out", str(summary_path)])
+        assert rc == 0
+        # Persist expected findings
+        for cid in ("SEC-001", "OBS-001"):
+            (findings_dir / f"{cid}-test.md").write_text("body", encoding="utf-8")
+        rc = main(["validate", str(audit_dir)])
+        assert rc == 0
+
+    def test_validate_command_fails_on_mismatch(self, tmp_path, minimal_results):
+        from tools.aggregate_results import main
+        audit_dir = tmp_path / "audit"
+        findings_dir = audit_dir / "findings"
+        findings_dir.mkdir(parents=True)
+        results_path = audit_dir / "verification-results.json"
+        summary_path = audit_dir / "summary.json"
+        self._write_results(results_path, minimal_results)
+        main(["aggregate", str(results_path), "--out", str(summary_path)])
+        # Persist nothing
+        rc = main(["validate", str(audit_dir)])
+        assert rc == 1
+
+    def test_expected_findings_command(self, tmp_path, minimal_results, capsys):
+        from tools.aggregate_results import main
+        results_path = tmp_path / "results.json"
+        self._write_results(results_path, minimal_results)
+        rc = main(["expected-findings", str(results_path)])
+        assert rc == 0
+        out = capsys.readouterr().out.strip().splitlines()
+        assert set(out) == {"SEC-001", "OBS-001"}

--- a/tools/aggregate_results.py
+++ b/tools/aggregate_results.py
@@ -1,0 +1,355 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Single source of truth for audit verification results.
+
+Solves the inconsistency observed in the first real audit (srgssr-mcp,
+2026-04-30) where Step 4 / Step 5 / final report each reported different
+counts because each step recomputed from a different intermediate.
+
+This module defines:
+  - The canonical verification-results JSON schema.
+  - The findings-persistence policy: which statuses warrant a finding doc.
+  - An aggregator that produces summary.json from verification-results.json.
+  - A validator that enforces `findings/*.md` matches the expected set.
+
+Statuses:
+  pass     — check fully satisfied
+  fail     — check failed; warrants a finding doc
+  partial  — partially satisfied; warrants a finding doc by default
+  todo     — needs manual review; no judgment yet, no finding doc
+  n/a      — not applicable to this profile (rarely persisted explicitly)
+
+Findings persistence policies:
+  fail-or-partial  (default)  — FAIL + PARTIAL → finding doc
+  fail-only                    — only FAIL → finding doc
+  needs-attention              — FAIL + PARTIAL + TODO → finding doc
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Iterable
+
+from tools.path_utils import force_utf8_stdio
+
+
+VALID_STATUSES = ("pass", "fail", "partial", "todo", "n/a")
+VALID_SEVERITIES = ("critical", "high", "medium", "low")
+
+POLICIES = {
+    "fail-or-partial": ("fail", "partial"),
+    "fail-only": ("fail",),
+    "needs-attention": ("fail", "partial", "todo"),
+}
+DEFAULT_POLICY = "fail-or-partial"
+
+BLOCKING_SEVERITIES = ("critical", "high")
+
+
+class AggregationError(Exception):
+    """Base class for schema, aggregation, and validation errors."""
+
+
+class ValidationError(AggregationError):
+    """Raised when persisted findings/ do not match the expected set."""
+
+
+# ---------------------------------------------------------------------------
+# Schema
+# ---------------------------------------------------------------------------
+
+@dataclass
+class CheckResult:
+    check_id: str
+    status: str
+    category: str
+    severity: str
+    evidence: list[str] = field(default_factory=list)
+    gaps: list[str] = field(default_factory=list)
+
+    def __post_init__(self) -> None:
+        if self.status not in VALID_STATUSES:
+            raise AggregationError(
+                f"{self.check_id}: invalid status {self.status!r}, "
+                f"expected one of {VALID_STATUSES}"
+            )
+        if self.severity not in VALID_SEVERITIES:
+            raise AggregationError(
+                f"{self.check_id}: invalid severity {self.severity!r}, "
+                f"expected one of {VALID_SEVERITIES}"
+            )
+
+
+@dataclass
+class VerificationResults:
+    audit_meta: dict[str, Any]
+    results: dict[str, CheckResult]
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "VerificationResults":
+        if not isinstance(data, dict):
+            raise AggregationError("Top-level results must be a dict")
+        if "results" not in data or not isinstance(data["results"], dict):
+            raise AggregationError("Missing 'results' object")
+        results: dict[str, CheckResult] = {}
+        for cid, raw in data["results"].items():
+            if not isinstance(raw, dict):
+                raise AggregationError(f"{cid}: result must be an object")
+            results[cid] = CheckResult(
+                check_id=cid,
+                status=raw.get("status", ""),
+                category=raw.get("category", ""),
+                severity=raw.get("severity", ""),
+                evidence=list(raw.get("evidence") or []),
+                gaps=list(raw.get("gaps") or []),
+            )
+        return cls(
+            audit_meta=dict(data.get("audit_meta") or {}),
+            results=results,
+        )
+
+    @classmethod
+    def from_path(cls, path: Path) -> "VerificationResults":
+        text = path.read_text(encoding="utf-8")
+        return cls.from_dict(json.loads(text))
+
+
+# ---------------------------------------------------------------------------
+# Aggregation
+# ---------------------------------------------------------------------------
+
+def aggregate(
+    vr: VerificationResults,
+    policy: str = DEFAULT_POLICY,
+) -> dict[str, Any]:
+    """Compute the canonical summary from verification results.
+
+    All downstream consumers (audit report, Notion sync, dashboards) must
+    read from this output rather than recomputing — this is the bug that
+    the inconsistency in the first real audit was caused by.
+    """
+    if policy not in POLICIES:
+        raise AggregationError(
+            f"Unknown findings policy {policy!r}; valid: {sorted(POLICIES)}"
+        )
+
+    by_status: dict[str, int] = {s: 0 for s in VALID_STATUSES}
+    by_severity: dict[str, int] = {s: 0 for s in VALID_SEVERITIES}
+    by_category: dict[str, dict[str, int]] = {}
+
+    finding_statuses = POLICIES[policy]
+    expected_findings: list[dict[str, Any]] = []
+    blocking: list[str] = []
+
+    for cid, r in sorted(vr.results.items()):
+        by_status[r.status] = by_status.get(r.status, 0) + 1
+        cat = by_category.setdefault(r.category, {s: 0 for s in VALID_STATUSES})
+        cat[r.status] = cat.get(r.status, 0) + 1
+
+        if r.status in finding_statuses:
+            by_severity[r.severity] = by_severity.get(r.severity, 0) + 1
+            expected_findings.append({
+                "check_id": cid,
+                "category": r.category,
+                "severity": r.severity,
+                "status": r.status,
+            })
+            if r.status == "fail" and r.severity in BLOCKING_SEVERITIES:
+                blocking.append(cid)
+
+    applicable = sum(
+        v for k, v in by_status.items() if k != "n/a"
+    )
+
+    summary = {
+        "audit_meta": vr.audit_meta,
+        "totals": {
+            "checks_evaluated": len(vr.results),
+            "applicable": applicable,
+            "by_status": by_status,
+            "by_severity_among_findings": by_severity,
+            "by_category": by_category,
+        },
+        "findings": {
+            "policy": policy,
+            "policy_statuses": list(finding_statuses),
+            "expected_count": len(expected_findings),
+            "expected_ids": [f["check_id"] for f in expected_findings],
+            "details": expected_findings,
+        },
+        "production_ready": len(blocking) == 0,
+        "blocking_findings": blocking,
+    }
+    return summary
+
+
+# ---------------------------------------------------------------------------
+# Validation
+# ---------------------------------------------------------------------------
+
+def list_finding_files(findings_dir: Path) -> list[Path]:
+    if not findings_dir.exists():
+        return []
+    return sorted(findings_dir.glob("*.md"))
+
+
+def extract_check_id_from_finding_filename(path: Path) -> str | None:
+    """Filenames are conventionally `<CHECK-ID>-<slug>.md`. Returns the
+    CHECK-ID prefix if recognisable, else None.
+    """
+    stem = path.stem
+    # Match category prefixes like ARCH-, SEC-, CH-, OBS-, OPS-, SCALE-, SDK-, HITL-
+    parts = stem.split("-")
+    if len(parts) >= 2 and parts[1].isdigit():
+        return f"{parts[0]}-{parts[1]}"
+    return None
+
+
+def validate_findings_persistence(
+    summary: dict[str, Any],
+    findings_dir: Path,
+) -> dict[str, Any]:
+    """Compare summary.findings.expected_ids against findings/*.md on disk.
+
+    Returns a structured report. Raises ValidationError if mismatched —
+    callers can catch and decide whether to surface as warning or hard fail.
+    """
+    expected = set(summary["findings"]["expected_ids"])
+    files = list_finding_files(findings_dir)
+    found: set[str] = set()
+    unrecognised: list[str] = []
+    for f in files:
+        cid = extract_check_id_from_finding_filename(f)
+        if cid is None:
+            unrecognised.append(f.name)
+        else:
+            found.add(cid)
+
+    missing = sorted(expected - found)
+    unexpected = sorted(found - expected)
+
+    report = {
+        "expected_count": len(expected),
+        "found_count": len(found),
+        "missing": missing,
+        "unexpected": unexpected,
+        "unrecognised_filenames": unrecognised,
+        "consistent": not (missing or unexpected),
+    }
+    if not report["consistent"]:
+        raise ValidationError(
+            "Findings on disk don't match summary.expected_ids: "
+            f"missing={missing}, unexpected={unexpected}"
+        )
+    return report
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="aggregate_results",
+        description="Single source of truth for audit verification results.",
+    )
+    sub = parser.add_subparsers(dest="cmd", required=True)
+
+    p_agg = sub.add_parser(
+        "aggregate",
+        help="Compute summary.json from verification-results.json",
+    )
+    p_agg.add_argument("results", help="Path to verification-results.json")
+    p_agg.add_argument(
+        "--policy",
+        choices=sorted(POLICIES),
+        default=DEFAULT_POLICY,
+        help=f"Findings persistence policy (default: {DEFAULT_POLICY})",
+    )
+    p_agg.add_argument(
+        "--out",
+        default=None,
+        help="Write summary.json to this path; otherwise print to stdout",
+    )
+
+    p_val = sub.add_parser(
+        "validate",
+        help="Verify findings/ directory matches summary.expected_ids",
+    )
+    p_val.add_argument(
+        "audit_dir",
+        help="Path to audit dir containing summary.json and findings/",
+    )
+    p_val.add_argument(
+        "--summary",
+        default=None,
+        help="Override summary.json path (default: <audit_dir>/summary.json)",
+    )
+    p_val.add_argument(
+        "--findings-dir",
+        default=None,
+        help="Override findings dir (default: <audit_dir>/findings)",
+    )
+
+    p_exp = sub.add_parser(
+        "expected-findings",
+        help="List the check IDs that must have a finding doc",
+    )
+    p_exp.add_argument("results", help="Path to verification-results.json")
+    p_exp.add_argument(
+        "--policy",
+        choices=sorted(POLICIES),
+        default=DEFAULT_POLICY,
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    force_utf8_stdio()
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+
+    if args.cmd == "aggregate":
+        vr = VerificationResults.from_path(Path(args.results))
+        summary = aggregate(vr, policy=args.policy)
+        text = json.dumps(summary, indent=2, ensure_ascii=False)
+        if args.out:
+            Path(args.out).write_text(text + "\n", encoding="utf-8")
+        else:
+            print(text)
+        return 0
+
+    if args.cmd == "validate":
+        audit_dir = Path(args.audit_dir)
+        summary_path = Path(args.summary) if args.summary else audit_dir / "summary.json"
+        findings_dir = (
+            Path(args.findings_dir) if args.findings_dir else audit_dir / "findings"
+        )
+        if not summary_path.exists():
+            print(f"Error: {summary_path} not found", file=sys.stderr)
+            return 2
+        summary = json.loads(summary_path.read_text(encoding="utf-8"))
+        try:
+            report = validate_findings_persistence(summary, findings_dir)
+        except ValidationError as e:
+            print(json.dumps({"consistent": False, "error": str(e)}, indent=2))
+            return 1
+        print(json.dumps(report, indent=2))
+        return 0
+
+    if args.cmd == "expected-findings":
+        vr = VerificationResults.from_path(Path(args.results))
+        summary = aggregate(vr, policy=args.policy)
+        for cid in summary["findings"]["expected_ids"]:
+            print(cid)
+        return 0
+
+    return 2
+
+
+if __name__ == "__main__":  # pragma: no cover
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Closes #8 (findings persistence vs. count inconsistency).
Closes #9 (single source of truth for status statistics).

The first real audit (`srgssr-mcp`, 2026-04-30) had three independent counters reporting three different numbers for the same data. Structural fix via a canonical aggregator that all downstream stages must consume.

## What changed

### `tools/aggregate_results.py` — canonical aggregator
- Reads `verification-results.json`, produces `summary.json`.
- Three CLI subcommands: `aggregate`, `expected-findings`, `validate`.
- Strict schema validation: `CheckResult` rejects invalid status/severity at load.
- Validation gate: `validate <audit_dir>` exits 1 if `findings/*.md` doesn't match `summary.expected_ids`.

### Findings-persistence policies
| Policy | Statuses → finding doc |
|---|---|
| `fail-or-partial` (default) | FAIL + PARTIAL |
| `fail-only` | FAIL only |
| `needs-attention` | FAIL + PARTIAL + TODO |

Policy must be set explicitly at Step 5 entry and is persisted in `summary.json`. All stages read the same policy, eliminating drift.

### Production-readiness rule
`production_ready = false` iff at least one `fail` with severity ∈ {`critical`, `high`}. PARTIAL high/critical is "in progress, not blocking" — that distinction was implicit in the audit but never codified before.

### `docs/verification-results-schema.md`
Formal contract between Step 4 (check execution), Step 5 (finding persistence), and Step 6 (report). Documents the bug that motivated this PR and the validation gate that prevents recurrence.

### `tests/test_aggregate_results.py` — 32 pytest cases
Most importantly, `test_srgssr_original_audit_bug_is_caught`: replays the exact srgssr scenario (write only 6 of 15 expected findings) and asserts the validator raises with `missing=...` listing the 9 unpersisted PARTIAL findings.

### SKILL.md updates
- New Step 5.0: findings-persistence rule (verbindlich) with full CLI workflow.
- Step 5.2: `tools/aggregate_results.py` is the single source for the Notion `Findings` field. Anti-pattern of `sum(1 for r in check_runs ...)` explicitly called out as wrong.
- Step 6.1: all numbers in the report MUST come from `summary.json`. Never re-aggregate from raw/.

## Test plan

- [x] `python -m pytest tests/` — 103 passing (71 → 103)
- [x] `python tools/aggregate_results.py aggregate ... --policy fail-or-partial` — produces summary with expected counts
- [x] `python tools/aggregate_results.py validate <dir>` — exits 0 when consistent, 1 when missing/unexpected
- [x] Regression test confirms the original srgssr bug is caught
- [ ] CI green on Ubuntu + Windows runners

## Out of scope (separate PRs)

- #11 — Replace remaining inline Python heredocs with `tools/` scripts (this PR adds another, but doesn't migrate existing)
- #12 — Validate Task-agent results before continuing
- #13 — `write_access` vs. `write_capable` schema migration
- #14 — Profile placeholder detection
- #15 — Audit run-id with timezone
- #16 — Migrate the 9 broken `applies_when` expressions


---
_Generated by [Claude Code](https://claude.ai/code/session_01PgYtwRK14HmFwES2PusuHH)_