### PR TITLE
Replace inline heredocs with parse_catalog.py + build_report.py (closes #11)

### DIFF
--- a/.claude/commands/audit-mcp.md
+++ b/.claude/commands/audit-mcp.md
@@ -1,7 +1,7 @@
 ---
 description: Audit eines MCP-Servers gegen den mcp-audit-skill v0.5.0-Katalog. Lädt Profil, filtert anwendbare Checks, führt automatisierte Verifikation aus, erzeugt Findings-Stubs und Audit-Report. Funktioniert mit lokalem Skill-Klon oder via WebFetch von GitHub-Raw (Cloud-Modus).
 argument-hint: <repo-url-or-local-path>
-allowed-tools: Bash(git:*), Bash(grep:*), Bash(find:*), Bash(curl:*), Bash(ls:*), Bash(cat:*), Bash(wc:*), Bash(head:*), Bash(tail:*), Bash(awk:*), Bash(sed:*), Bash(jq:*), Bash(test:*), Read, Write, Glob, WebFetch
+allowed-tools: Bash(git:*), Bash(grep:*), Bash(find:*), Bash(curl:*), Bash(ls:*), Bash(cat:*), Bash(wc:*), Bash(head:*), Bash(tail:*), Bash(awk:*), Bash(sed:*), Bash(jq:*), Bash(test:*), Bash(python:*), Bash(python3:*), Read, Write, Glob, WebFetch
 ---
 
 # /audit-mcp — MCP-Server Audit-Workflow
@@ -87,20 +87,19 @@ Daraus baust du das Profil mit folgenden Variablen (Defaults bei Unsicherheit):
 
 Lade die Check-Liste aus dem Manifest und parse für jeden Check die Frontmatter (zwischen den ersten beiden `---`-Markern) mit den Feldern: `id`, `title`, `category`, `severity`, `applies_when`, `pdf_ref`, `evidence_required`.
 
-**Modus `local`:**
+**Modus `local` — bevorzugt: Helper-Script aufrufen, niemals Inline-Heredocs:**
 
 ```bash
-# Manifest gibt die kanonische Liste; *.md ist Sanity-Check.
-cat $SKILL_BASE/checks/MANIFEST.txt
-ls $SKILL_BASE/checks/*.md | sort
+# Single-Source-of-Truth-Parser. Ersetzt frühere awk/heredoc-Loops, die
+# auf Windows Git Bash mehrfach an Quoting-Bugs gecrasht sind.
+python "$SKILL_BASE/tools/parse_catalog.py" --checks-dir "$SKILL_BASE/checks" --format json > catalog.json
 
-# Frontmatter pro File extrahieren
-for f in $SKILL_BASE/checks/*.md; do
-  awk '/^---$/{c++; next} c==1' "$f" | head -10
-  echo "FILE: $f"
-  echo "---"
-done
+# Konsistenz-Gate (MANIFEST.txt vs *.md):
+python "$SKILL_BASE/tools/parse_catalog.py" --checks-dir "$SKILL_BASE/checks" --format manifest-check
+# exit 0 = consistent, exit 1 = drift (siehe in_manifest_only / in_catalog_only)
 ```
+
+Für eine schnelle visuelle Übersicht: `--format table` zeigt ID, Kategorie, Severity, applies_when in einer Spalten-Ansicht.
 
 **Modus `remote`:**
 
@@ -206,20 +205,28 @@ Pro Finding ein File: `$OUTPUT_DIR/findings/<check-id>-<short-slug>.md` mit:
 
 ### Schritt 6 — Report-Output
 
-Lade das Audit-Report-Template:
-- `SKILL_MODE=local`: `Read $SKILL_BASE/templates/audit-report.md`.
-- `SKILL_MODE=remote`: WebFetch `$SKILL_BASE/templates/audit-report.md` mit Prompt «Gib den vollständigen Markdown-Quelltext wortgetreu zurück.»
+**Bevorzugt: Helper-Script aufrufen, niemals Inline-Python-Heredocs.** Letztere sind in der Vergangenheit auf Windows Git Bash an Quoting-Bugs gecrasht. Der Generator liest `summary.json` (Single-Source-of-Truth aus Step 5) und alle Files in `findings/` und produziert deterministisch denselben Report.
 
-Fülle das Template mit den gesammelten Daten und schreibe das Ergebnis nach `$OUTPUT_DIR/audit-report.md`.
+```bash
+# 1. Vor Step 6: Validation-Gate sicherstellen (siehe Step 5)
+python "$SKILL_BASE/tools/aggregate_results.py" validate "$OUTPUT_DIR"
 
-Pflicht-Sektionen:
+# 2. Report aus summary.json + findings/ rendern
+python "$SKILL_BASE/tools/build_report.py" "$OUTPUT_DIR" \
+    --profile path/to/profile.yaml
+```
 
-1. **Executive Summary** — 3 Sätze max: Anzahl anwendbarer Checks, Anzahl Findings nach Severity, Production-Readiness (✅ ja wenn 0 critical und ≤ 2 high; ❌ sonst).
-2. **Profile** — der bestätigte Profil-Block aus Schritt 1.
-3. **Coverage** — Tabelle pro Kategorie: Total / Anwendbar / Pass / Fail / Partial / TODO.
-4. **Findings** — Liste aller erzeugten Findings, gruppiert nach Severity.
-5. **Open TODOs** — Liste aller `TODO`-Status-Checks mit den Such-Pattern aus dem Check-File. Damit kann der menschliche Auditor die manuellen Schritte abarbeiten.
-6. **Anhang** — Liste der Roh-Output-Files in `raw/`.
+Der Output landet als `$OUTPUT_DIR/audit-report.md`. Sektionen werden aus `summary.json` gelesen — wenn dort etwas fehlt, ist `tools/aggregate_results.py` falsch aufgerufen worden, NICHT manuell den Report patchen.
+
+**Pflicht-Sektionen (vom Generator automatisch befüllt):**
+
+1. **Executive Summary** — Server, Anzahl Checks, Findings-Counts, Production-Readiness, Blocking-Findings.
+2. **Profile-Snapshot** — relevante Profil-Felder.
+3. **Applicability** — Tabelle pro Kategorie: Pass/Fail/Partial/TODO/N/A.
+4. **Findings-Übersicht** — alle Findings nach Severity sortiert.
+5. **Detail-Findings** — Inhalt der `findings/<ID>-*.md`-Files eingebettet.
+6. **Remediation-Plan** — Reihenfolge nach Severity.
+7. **Audit-Metadata** — Skill-Version, Catalog-Version, Policy.
 
 **Output Schritt 6:** Pfad zum Report-File. Plus Klartext-Empfehlung: «Production-Ready ja/nein, nächste Schritte sind: ...».
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ Versionierung: [Semantic Versioning](https://semver.org/lang/de/).
 
 ## [Unreleased]
 
+### Hinzugefügt — Catalog-Parser und Report-Builder (Issue #11)
+
+Inline-Heredocs sind jetzt vollständig durch dedizierte Helper-Scripts ersetzt. Im ersten realen Audit wurden Inline-Python-Blöcke ad hoc generiert, was auf Windows Git Bash mehrfach an Quoting gecrasht ist.
+
+- **`tools/parse_catalog.py`** — parst alle Check-Frontmatter, validiert MANIFEST.txt-Konsistenz, listet Kategorien/Severities. CLI: `--format {json,table,manifest-check}`. Pflicht-Felder werden hart enforced (jede Inkonsistenz crasht laut, statt stille Defaults).
+- **`tools/build_report.py`** — generiert `audit-report.md` aus `summary.json` + `findings/` + Profile. Sieben Pflicht-Sektionen, deterministisch reproduzierbar. Findings werden nach Severity sortiert; fehlende Finding-Docs werden im Report explizit als Validation-Lücke markiert.
+- **Standalone-Bootstrap fix** — `aggregate_results.py` und `parse_catalog.py` setzen jetzt `sys.path` für Direktaufruf via `python tools/<x>.py`. Vorher funktionierten sie nur via pytest.
+- **SKILL.md Step 0.3** — Inline-Heredocs sind jetzt explizit verboten; Tabelle aller Helper-Scripts mit Aufgabe/Aufruf.
+- **Slash-Command `audit-mcp.md`** — Step 2 und Step 6 rufen Helper-Scripts statt Inline-Loops auf. `python`/`python3` zu allowed-tools hinzugefügt.
+- **36 neue pytest cases** — `tests/test_parse_catalog.py` (16) + `tests/test_build_report.py` (20). Test-Total: 103 → 139.
+
 ### Hinzugefügt — Findings-Persistenz-Aggregator (Single-Source-of-Truth)
 
 Behebt Issues #8 (Findings-Persistenz) und #9 (Status-Drift). Im ersten Audit (`srgssr-mcp`, 2026-04-30) berichteten drei Stages drei verschiedene Zahlen für dieselben Daten — Step 5 sagte 15 Findings, Step 6 sagte 6, auf Disk waren 6. Strukturelle Lösung:

--- a/SKILL.md
+++ b/SKILL.md
@@ -61,15 +61,21 @@ from tools.path_utils import to_native_path, to_posix_path, is_windows
 read_path = to_native_path(skill_base)   # für Read-Tool-Aufrufe
 ```
 
-### 0.3 Inline-Heredocs vermeiden
+### 0.3 Inline-Heredocs sind verboten
 
-Inline-`python3 << 'PYEOF'`-Blöcke crashen auf Windows Git Bash regelmässig durch Quoting. Nutze stattdessen Helper-Scripts unter `tools/`:
+Inline-`python3 << 'PYEOF'`-Blöcke crashen auf Windows Git Bash regelmässig durch Quoting (Issue #11, real beobachtet im srgssr-Audit). Für jede nicht-triviale Operation existiert ein dediziertes Helper-Script unter `tools/`. **Verwende diese, schreibe niemals Inline-Python während eines Audits:**
 
-```bash
-# Statt heredoc:
-python tools/eval_applicability.py catalog "$profile" --format table
-python tools/path_utils.py to-native "$path"
-```
+| Aufgabe | Helper-Script |
+|---|---|
+| Catalog parsen (Frontmatter aller `*.md`) | `python tools/parse_catalog.py --format json` |
+| Catalog vs. Manifest validieren | `python tools/parse_catalog.py --format manifest-check` |
+| `applies_when` evaluieren | `python tools/eval_applicability.py catalog profile.yaml` |
+| Verification-Results aggregieren | `python tools/aggregate_results.py aggregate results.json --out summary.json` |
+| Findings-Set vs. Disk validieren | `python tools/aggregate_results.py validate <audit_dir>` |
+| Audit-Report generieren | `python tools/build_report.py <audit_dir>` |
+| Pfad zu Native/POSIX konvertieren | `python tools/path_utils.py to-native <path>` |
+
+Wenn ein Audit ein Snippet braucht das hier nicht abgedeckt ist: erst Issue im Skill-Repo öffnen, dann Helper-Script bauen, dann verwenden. **Inline-Heredoc ist der Anti-Pattern, der nicht-reproduzierbare Audits erzeugt.**
 
 ---
 

--- a/tests/test_build_report.py
+++ b/tests/test_build_report.py
@@ -1,0 +1,267 @@
+# -*- coding: utf-8 -*-
+"""Tests for tools/build_report.py — audit-report generation from summary.json."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from tools.aggregate_results import (
+    CheckResult,
+    VerificationResults,
+    aggregate,
+)
+from tools.build_report import (
+    build_report,
+    main,
+    render_applicability,
+    render_executive_summary,
+    render_findings_table,
+    render_metadata,
+    render_profile_snapshot,
+    render_remediation_plan,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def srgssr_summary() -> dict:
+    """Summary mirroring the srgssr-mcp audit (FAIL+PARTIAL policy)."""
+    vr = VerificationResults(
+        audit_meta={
+            "server_name": "srgssr-mcp",
+            "audit_date": "2026-04-30",
+            "skill_version": "0.8-test",
+            "catalog_version": "2026-04",
+            "policy": "fail-or-partial",
+        },
+        results={
+            "ARCH-001": CheckResult("ARCH-001", "pass", "ARCH", "medium"),
+            "ARCH-002": CheckResult("ARCH-002", "fail", "ARCH", "medium"),
+            "OPS-001": CheckResult("OPS-001", "fail", "OPS", "high"),
+            "SEC-021": CheckResult("SEC-021", "partial", "SEC", "medium"),
+        },
+    )
+    return aggregate(vr)
+
+
+@pytest.fixture
+def empty_summary() -> dict:
+    """All checks pass — clean audit."""
+    vr = VerificationResults(
+        audit_meta={"server_name": "perfect-mcp", "audit_date": "2026-05-02"},
+        results={
+            "ARCH-001": CheckResult("ARCH-001", "pass", "ARCH", "medium"),
+            "SEC-001": CheckResult("SEC-001", "pass", "SEC", "high"),
+        },
+    )
+    return aggregate(vr)
+
+
+@pytest.fixture
+def sample_profile() -> dict:
+    return {
+        "transport": "stdio-only",
+        "auth_model": "none",
+        "data_class": "Public Open Data",
+        "write_capable": False,
+        "deployment": ["local-stdio"],
+        "tools_make_external_requests": True,
+        "data_source": {"is_swiss_open_data": True},
+    }
+
+
+# ---------------------------------------------------------------------------
+# Section renderers
+# ---------------------------------------------------------------------------
+
+class TestExecutiveSummary:
+    def test_includes_server_name(self, srgssr_summary):
+        out = render_executive_summary(srgssr_summary)
+        assert "srgssr-mcp" in out
+        assert "Production-Readiness" in out
+
+    def test_blocking_findings_called_out(self, srgssr_summary):
+        out = render_executive_summary(srgssr_summary)
+        assert "OPS-001" in out  # blocking finding
+        assert "NICHT erreicht" in out
+
+    def test_clean_audit_marks_ready(self, empty_summary):
+        out = render_executive_summary(empty_summary)
+        assert "Production-Readiness:" in out
+        assert "YES" in out
+        assert "erreicht" in out and "NICHT" not in out
+
+
+class TestProfileSnapshot:
+    def test_renders_known_profile_fields(self, srgssr_summary, sample_profile):
+        out = render_profile_snapshot(srgssr_summary, sample_profile)
+        assert "stdio-only" in out
+        assert "Public Open Data" in out
+        assert "is_swiss_open_data" in out
+
+    def test_works_without_profile(self, srgssr_summary):
+        out = render_profile_snapshot(srgssr_summary, {})
+        assert "srgssr-mcp" in out
+        assert "Audit-Datum" in out
+
+
+class TestApplicability:
+    def test_status_table_includes_categories(self, srgssr_summary):
+        out = render_applicability(srgssr_summary)
+        assert "ARCH" in out
+        assert "SEC" in out
+        assert "OPS" in out
+        assert "Total" in out
+
+    def test_counts_match_summary(self, srgssr_summary):
+        out = render_applicability(srgssr_summary)
+        bs = srgssr_summary["totals"]["by_status"]
+        # Total row uses bold formatting
+        assert f"**{bs['pass']}**" in out
+        assert f"**{bs['fail']}**" in out
+
+
+class TestFindingsTable:
+    def test_lists_expected_findings(self, srgssr_summary):
+        out = render_findings_table(srgssr_summary)
+        assert "ARCH-002" in out
+        assert "OPS-001" in out
+        assert "SEC-021" in out
+
+    def test_severity_sort_high_first(self, srgssr_summary):
+        out = render_findings_table(srgssr_summary)
+        ops_pos = out.index("OPS-001")
+        sec_pos = out.index("SEC-021")
+        # OPS-001 is high → should appear before SEC-021 (medium)
+        assert ops_pos < sec_pos
+
+    def test_empty_findings_handled(self, empty_summary):
+        out = render_findings_table(empty_summary)
+        assert "Keine Findings" in out
+
+    def test_policy_disclosed(self, srgssr_summary):
+        out = render_findings_table(srgssr_summary)
+        assert "fail-or-partial" in out
+
+
+class TestRemediationPlan:
+    def test_lists_findings_in_order(self, srgssr_summary):
+        out = render_remediation_plan(srgssr_summary)
+        ops_pos = out.index("OPS-001")
+        sec_pos = out.index("SEC-021")
+        assert ops_pos < sec_pos
+
+    def test_empty_findings_handled(self, empty_summary):
+        out = render_remediation_plan(empty_summary)
+        assert "Keine Findings" in out
+
+
+class TestMetadata:
+    def test_includes_skill_version(self, srgssr_summary):
+        out = render_metadata(srgssr_summary)
+        assert "skill_version" in out
+        assert "0.8-test" in out
+
+
+# ---------------------------------------------------------------------------
+# End-to-end build
+# ---------------------------------------------------------------------------
+
+class TestBuildReport:
+    def test_full_report_includes_all_sections(
+        self, tmp_path, srgssr_summary, sample_profile,
+    ):
+        findings_dir = tmp_path / "findings"
+        findings_dir.mkdir()
+        for cid in srgssr_summary["findings"]["expected_ids"]:
+            (findings_dir / f"{cid}-test.md").write_text(
+                f"## Finding: {cid}\n\nbody for {cid}\n",
+                encoding="utf-8",
+            )
+        report = build_report(srgssr_summary, sample_profile, findings_dir)
+        assert "## 1. Executive Summary" in report
+        assert "## 2. Profil-Snapshot" in report
+        assert "## 3. Applicability" in report
+        assert "## 4. Findings-Übersicht" in report
+        assert "## 5. Detail-Findings" in report
+        assert "## 6. Remediation-Plan" in report
+        assert "## 7. Audit-Metadata" in report
+        # All findings embedded by ID
+        for cid in srgssr_summary["findings"]["expected_ids"]:
+            assert cid in report
+            assert f"body for {cid}" in report
+
+    def test_missing_finding_doc_flagged_in_report(
+        self, tmp_path, srgssr_summary,
+    ):
+        findings_dir = tmp_path / "findings"
+        findings_dir.mkdir()
+        # Persist only one of three expected findings.
+        (findings_dir / "ARCH-002-test.md").write_text(
+            "## Finding: ARCH-002\n\ndocumented\n", encoding="utf-8",
+        )
+        report = build_report(srgssr_summary, {}, findings_dir)
+        # Missing findings get a warning section
+        assert "missing finding doc" in report
+        assert "OPS-001" in report
+        assert "SEC-021" in report
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+class TestCli:
+    def _setup_audit_dir(
+        self,
+        tmp_path: Path,
+        summary: dict,
+        profile: dict | None = None,
+    ) -> Path:
+        audit_dir = tmp_path / "audit"
+        findings_dir = audit_dir / "findings"
+        findings_dir.mkdir(parents=True)
+        (audit_dir / "summary.json").write_text(
+            json.dumps(summary), encoding="utf-8",
+        )
+        for cid in summary["findings"]["expected_ids"]:
+            (findings_dir / f"{cid}-test.md").write_text(
+                f"## {cid}\nbody\n", encoding="utf-8",
+            )
+        if profile:
+            (audit_dir / "profile.json").write_text(
+                json.dumps(profile), encoding="utf-8",
+            )
+        return audit_dir
+
+    def test_cli_writes_default_path(self, tmp_path, srgssr_summary):
+        audit_dir = self._setup_audit_dir(tmp_path, srgssr_summary)
+        rc = main([str(audit_dir)])
+        assert rc == 0
+        out = audit_dir / "audit-report.md"
+        assert out.exists()
+        text = out.read_text(encoding="utf-8")
+        assert "srgssr-mcp" in text
+
+    def test_cli_with_profile(self, tmp_path, srgssr_summary, sample_profile):
+        audit_dir = self._setup_audit_dir(tmp_path, srgssr_summary, sample_profile)
+        rc = main([str(audit_dir), "--profile", str(audit_dir / "profile.json")])
+        assert rc == 0
+        out = (audit_dir / "audit-report.md").read_text(encoding="utf-8")
+        assert "stdio-only" in out
+
+    def test_cli_custom_out_path(self, tmp_path, srgssr_summary):
+        audit_dir = self._setup_audit_dir(tmp_path, srgssr_summary)
+        out_path = tmp_path / "custom.md"
+        rc = main([str(audit_dir), "--out", str(out_path)])
+        assert rc == 0
+        assert out_path.exists()
+
+    def test_cli_missing_summary_returns_two(self, tmp_path):
+        rc = main([str(tmp_path)])
+        assert rc == 2

--- a/tests/test_parse_catalog.py
+++ b/tests/test_parse_catalog.py
@@ -1,0 +1,214 @@
+# -*- coding: utf-8 -*-
+"""Tests for tools/parse_catalog.py — replaces inline awk/heredoc parsing."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from tools.parse_catalog import (
+    REQUIRED_FIELDS,
+    category_counts,
+    list_check_files,
+    main,
+    manifest_check,
+    parse_catalog,
+    severity_counts,
+)
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+CHECKS_DIR = REPO_ROOT / "checks"
+
+
+# ---------------------------------------------------------------------------
+# Real-catalog regression
+# ---------------------------------------------------------------------------
+
+class TestRealCatalog:
+    def test_count_matches_manifest(self):
+        catalog = parse_catalog(CHECKS_DIR)
+        assert len(catalog) == 68
+
+    def test_all_required_fields_present(self):
+        catalog = parse_catalog(CHECKS_DIR)
+        for cid, fm in catalog.items():
+            for f in REQUIRED_FIELDS:
+                assert fm.get(f), f"{cid}: missing required field {f}"
+
+    def test_manifest_consistent_with_catalog(self):
+        report = manifest_check(CHECKS_DIR)
+        assert report["consistent"] is True
+        assert report["in_manifest_only"] == []
+        assert report["in_catalog_only"] == []
+        assert report["manifest_count"] == 68
+        assert report["catalog_count"] == 68
+
+    def test_category_distribution(self):
+        catalog = parse_catalog(CHECKS_DIR)
+        counts = category_counts(catalog)
+        # Expected per SKILL.md table.
+        assert counts == {
+            "ARCH": 12,
+            "CH": 8,
+            "HITL": 5,
+            "OBS": 6,
+            "OPS": 3,
+            "SCALE": 6,
+            "SDK": 5,
+            "SEC": 23,
+        }
+
+    def test_severity_distribution_known_set(self):
+        catalog = parse_catalog(CHECKS_DIR)
+        counts = severity_counts(catalog)
+        # Severities must be a subset of the canonical 4.
+        assert set(counts).issubset({"critical", "high", "medium", "low"})
+        assert sum(counts.values()) == 68
+
+
+# ---------------------------------------------------------------------------
+# Hermetic fixtures
+# ---------------------------------------------------------------------------
+
+def _write_check(dir: Path, fm: str, body: str = "body") -> None:
+    path = dir / f"{fm.split('id:')[1].split()[0].strip()}.md"
+    path.write_text(f"---\n{fm}\n---\n\n{body}\n", encoding="utf-8")
+
+
+class TestHermetic:
+    def test_two_checks_parse(self, tmp_path):
+        _write_check(tmp_path,
+            "id: TST-001\n"
+            "title: \"Tiny check\"\n"
+            "category: ARCH\n"
+            "severity: medium\n"
+            "applies_when: 'always'"
+        )
+        _write_check(tmp_path,
+            "id: TST-002\n"
+            "title: \"Other tiny check\"\n"
+            "category: SEC\n"
+            "severity: high\n"
+            "applies_when: 'transport != \"stdio-only\"'"
+        )
+        catalog = parse_catalog(tmp_path)
+        assert set(catalog) == {"TST-001", "TST-002"}
+        assert catalog["TST-002"]["severity"] == "high"
+
+    def test_duplicate_id_rejected(self, tmp_path):
+        (tmp_path / "a.md").write_text(
+            "---\nid: SAME-001\ntitle: \"a\"\ncategory: ARCH\nseverity: medium\napplies_when: 'always'\n---\n",
+            encoding="utf-8",
+        )
+        (tmp_path / "b.md").write_text(
+            "---\nid: SAME-001\ntitle: \"b\"\ncategory: ARCH\nseverity: medium\napplies_when: 'always'\n---\n",
+            encoding="utf-8",
+        )
+        with pytest.raises(ValueError, match="Duplicate check id"):
+            parse_catalog(tmp_path)
+
+    def test_missing_required_field_rejected(self, tmp_path):
+        (tmp_path / "x.md").write_text(
+            "---\nid: TST-099\ntitle: \"x\"\ncategory: ARCH\nseverity: medium\n---\n",
+            encoding="utf-8",
+        )
+        with pytest.raises(ValueError, match="missing required field"):
+            parse_catalog(tmp_path)
+
+    def test_manifest_check_detects_orphan_file(self, tmp_path):
+        # Catalog has 1, manifest is empty
+        _write_check(tmp_path,
+            "id: ORPH-001\n"
+            "title: \"Orphan\"\n"
+            "category: ARCH\n"
+            "severity: medium\n"
+            "applies_when: 'always'"
+        )
+        (tmp_path / "MANIFEST.txt").write_text("", encoding="utf-8")
+        report = manifest_check(tmp_path)
+        assert report["consistent"] is False
+        assert report["in_catalog_only"] == ["ORPH-001"]
+        assert report["in_manifest_only"] == []
+
+    def test_manifest_check_detects_missing_file(self, tmp_path):
+        # Manifest references a check not on disk
+        (tmp_path / "MANIFEST.txt").write_text(
+            "GHOST-001\n", encoding="utf-8"
+        )
+        report = manifest_check(tmp_path)
+        assert report["consistent"] is False
+        assert report["in_manifest_only"] == ["GHOST-001"]
+
+    def test_list_check_files_excludes_manifest(self, tmp_path):
+        _write_check(tmp_path,
+            "id: TST-010\n"
+            "title: \"x\"\n"
+            "category: ARCH\n"
+            "severity: medium\n"
+            "applies_when: 'always'"
+        )
+        (tmp_path / "MANIFEST.txt").write_text("TST-010\n", encoding="utf-8")
+        files = list_check_files(tmp_path)
+        # MANIFEST.txt is not a .md, so it isn't picked up.
+        assert [p.name for p in files] == ["TST-010.md"]
+
+
+# ---------------------------------------------------------------------------
+# CLI smoke tests
+# ---------------------------------------------------------------------------
+
+class TestCli:
+    def test_json_format_to_stdout(self, tmp_path, capsys):
+        _write_check(tmp_path,
+            "id: CLI-001\n"
+            "title: \"x\"\n"
+            "category: ARCH\n"
+            "severity: medium\n"
+            "applies_when: 'always'"
+        )
+        rc = main(["--checks-dir", str(tmp_path), "--format", "json"])
+        assert rc == 0
+        out = capsys.readouterr().out
+        data = json.loads(out)
+        assert "CLI-001" in data
+
+    def test_json_format_to_file(self, tmp_path):
+        _write_check(tmp_path,
+            "id: FIL-001\n"
+            "title: \"x\"\n"
+            "category: ARCH\n"
+            "severity: medium\n"
+            "applies_when: 'always'"
+        )
+        out = tmp_path / "catalog.json"
+        rc = main([
+            "--checks-dir", str(tmp_path),
+            "--format", "json",
+            "--out", str(out),
+        ])
+        assert rc == 0
+        data = json.loads(out.read_text(encoding="utf-8"))
+        assert "FIL-001" in data
+
+    def test_manifest_check_consistent_returns_zero(self):
+        rc = main(["--checks-dir", str(CHECKS_DIR), "--format", "manifest-check"])
+        assert rc == 0
+
+    def test_manifest_check_inconsistent_returns_one(self, tmp_path, capsys):
+        # Catalog has one file, manifest is empty → inconsistent.
+        _write_check(tmp_path,
+            "id: INC-001\n"
+            "title: \"x\"\n"
+            "category: ARCH\n"
+            "severity: medium\n"
+            "applies_when: 'always'"
+        )
+        (tmp_path / "MANIFEST.txt").write_text("", encoding="utf-8")
+        rc = main(["--checks-dir", str(tmp_path), "--format", "manifest-check"])
+        assert rc == 1
+
+    def test_invalid_dir_returns_two(self, tmp_path):
+        rc = main(["--checks-dir", str(tmp_path / "nope"), "--format", "json"])
+        assert rc == 2

--- a/tools/aggregate_results.py
+++ b/tools/aggregate_results.py
@@ -34,7 +34,13 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Iterable
 
-from tools.path_utils import force_utf8_stdio
+# Make `tools.*` importable when this script is invoked directly
+# (e.g. `python tools/aggregate_results.py`) and not as part of a package.
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from tools.path_utils import force_utf8_stdio  # noqa: E402
 
 
 VALID_STATUSES = ("pass", "fail", "partial", "todo", "n/a")

--- a/tools/build_report.py
+++ b/tools/build_report.py
@@ -1,0 +1,382 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Render the final audit-report.md from summary.json + findings/.
+
+Replaces the inline Python heredocs that the original SKILL Step 6 used to
+generate ad-hoc — the original audit run on Windows hit Bash quoting
+crashes when the heredocs got too clever (issue #11).
+
+Inputs:
+    summary.json   — produced by tools/aggregate_results.py aggregate
+    findings/      — directory of finding-doc files (one per check id)
+    profile.yaml   — the server profile from Step 1 (optional but recommended)
+
+Output:
+    audit-report.md — final stakeholder-facing report
+
+Usage:
+    python tools/build_report.py audits/<run>/
+    python tools/build_report.py audits/<run>/ --profile profile.yaml --out report.md
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+# Bootstrap so tools.* imports work when invoked as a script.
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from tools.path_utils import force_utf8_stdio  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+SEVERITY_ORDER = ("critical", "high", "medium", "low")
+
+
+def _load_summary(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _load_profile(path: Path | None) -> dict[str, Any]:
+    if path is None or not path.exists():
+        return {}
+    text = path.read_text(encoding="utf-8")
+    if path.suffix == ".json":
+        return json.loads(text)
+    try:
+        import yaml  # type: ignore[import-not-found]
+    except ImportError:
+        return {}
+    data = yaml.safe_load(text)
+    if isinstance(data, dict) and "servers" in data and isinstance(data["servers"], list) and data["servers"]:
+        first = data["servers"][0]
+        return first.get("profile", first) if isinstance(first, dict) else {}
+    if isinstance(data, dict) and "profile" in data:
+        return data["profile"]
+    return data if isinstance(data, dict) else {}
+
+
+def _list_findings(findings_dir: Path) -> list[Path]:
+    if not findings_dir.exists():
+        return []
+    return sorted(findings_dir.glob("*.md"))
+
+
+def _ready_marker(production_ready: bool) -> str:
+    return "ready" if production_ready else "not-ready"
+
+
+# ---------------------------------------------------------------------------
+# Section renderers
+# ---------------------------------------------------------------------------
+
+def render_executive_summary(summary: dict[str, Any]) -> str:
+    server = summary.get("audit_meta", {}).get("server_name", "<server>")
+    totals = summary.get("totals", {})
+    by_status = totals.get("by_status", {})
+    findings = summary.get("findings", {})
+    by_sev = totals.get("by_severity_among_findings", {})
+    blocking = summary.get("blocking_findings", [])
+
+    sentence_1 = (
+        f"Server `{server}` wurde gegen {totals.get('applicable', 0)} "
+        f"anwendbare Best-Practice-Checks geprüft."
+    )
+    sentence_2 = (
+        f"{by_status.get('pass', 0)} bestanden, "
+        f"{findings.get('expected_count', 0)} Findings dokumentiert "
+        f"({by_sev.get('critical', 0)} critical, "
+        f"{by_sev.get('high', 0)} high, "
+        f"{by_sev.get('medium', 0)} medium, "
+        f"{by_sev.get('low', 0)} low)."
+    )
+    if summary.get("production_ready"):
+        sentence_3 = "Production-Readiness: erreicht."
+    else:
+        if blocking:
+            ids = ", ".join(blocking)
+            sentence_3 = (
+                f"Production-Readiness: NICHT erreicht — blockierend: {ids}."
+            )
+        else:
+            sentence_3 = (
+                "Production-Readiness: NICHT erreicht — siehe Findings-Tabelle."
+            )
+
+    return (
+        "## 1. Executive Summary\n\n"
+        f"{sentence_1} {sentence_2} {sentence_3}\n\n"
+        f"**Production-Readiness:** "
+        f"{'YES' if summary.get('production_ready') else 'NO'}\n"
+    )
+
+
+def render_profile_snapshot(
+    summary: dict[str, Any],
+    profile: dict[str, Any],
+) -> str:
+    out = ["## 2. Profil-Snapshot\n"]
+    meta = summary.get("audit_meta", {})
+    out.append("| Feld | Wert |")
+    out.append("|---|---|")
+    out.append(f"| Server-Name | `{meta.get('server_name', '?')}` |")
+    out.append(f"| Audit-Datum | {meta.get('audit_date', '?')} |")
+    out.append(f"| Skill-Version | {meta.get('skill_version', '?')} |")
+    out.append(f"| Catalog-Version | {meta.get('catalog_version', '?')} |")
+    if profile:
+        for key in (
+            "transport", "auth_model", "data_class", "write_capable",
+            "deployment", "uses_sampling", "tools_make_external_requests",
+            "stadt_zuerich_context", "schulamt_context",
+        ):
+            if key in profile:
+                out.append(f"| {key} | `{profile[key]}` |")
+        ds = profile.get("data_source")
+        if isinstance(ds, dict) and "is_swiss_open_data" in ds:
+            out.append(
+                f"| data_source.is_swiss_open_data | "
+                f"`{ds['is_swiss_open_data']}` |"
+            )
+    out.append("")
+    return "\n".join(out)
+
+
+def render_applicability(summary: dict[str, Any]) -> str:
+    totals = summary.get("totals", {})
+    by_cat = totals.get("by_category", {})
+    out = ["## 3. Applicability\n"]
+    out.append("### Status pro Kategorie\n")
+    out.append("| Kategorie | Pass | Fail | Partial | Todo | N/A |")
+    out.append("|---|---|---|---|---|---|")
+    for cat in sorted(by_cat):
+        c = by_cat[cat]
+        out.append(
+            f"| {cat} | {c.get('pass', 0)} | {c.get('fail', 0)} | "
+            f"{c.get('partial', 0)} | {c.get('todo', 0)} | {c.get('n/a', 0)} |"
+        )
+    bs = totals.get("by_status", {})
+    out.append(
+        f"| **Total** | **{bs.get('pass', 0)}** | **{bs.get('fail', 0)}** | "
+        f"**{bs.get('partial', 0)}** | **{bs.get('todo', 0)}** | "
+        f"**{bs.get('n/a', 0)}** |"
+    )
+    out.append("")
+    return "\n".join(out)
+
+
+def render_findings_table(summary: dict[str, Any]) -> str:
+    findings = summary.get("findings", {})
+    details = findings.get("details", [])
+    out = ["## 4. Findings-Übersicht\n"]
+    out.append(f"_Policy: `{findings.get('policy', '?')}`_\n")
+    if not details:
+        out.append("_Keine Findings — alle anwendbaren Checks bestanden._\n")
+        return "\n".join(out)
+    out.append("| ID | Category | Severity | Status |")
+    out.append("|---|---|---|---|")
+    # Sort by severity then category then id
+    sev_idx = {s: i for i, s in enumerate(SEVERITY_ORDER)}
+    sorted_details = sorted(
+        details,
+        key=lambda d: (
+            sev_idx.get(d.get("severity", "low"), 99),
+            d.get("category", ""),
+            d.get("check_id", ""),
+        ),
+    )
+    for d in sorted_details:
+        out.append(
+            f"| {d.get('check_id')} | {d.get('category')} | "
+            f"{d.get('severity')} | {d.get('status')} |"
+        )
+    out.append("")
+    out.append(f"**Gesamt:** {findings.get('expected_count', 0)} Findings")
+    out.append("")
+    return "\n".join(out)
+
+
+def render_detail_findings(
+    summary: dict[str, Any],
+    findings_dir: Path,
+) -> str:
+    out = ["## 5. Detail-Findings\n"]
+    expected = summary.get("findings", {}).get("expected_ids", [])
+    if not expected:
+        out.append("_Keine Findings._\n")
+        return "\n".join(out)
+    files = _list_findings(findings_dir)
+    by_id: dict[str, Path] = {}
+    for f in files:
+        # Filenames follow `<CHECK-ID>-<slug>.md`.
+        parts = f.stem.split("-")
+        if len(parts) >= 2 and parts[1].isdigit():
+            by_id[f"{parts[0]}-{parts[1]}"] = f
+    for cid in expected:
+        path = by_id.get(cid)
+        if path is None:
+            out.append(f"### {cid} — _missing finding doc_\n")
+            out.append(
+                "_Validation gate failed: this finding was expected but no "
+                "document was persisted. Run "
+                "`python tools/aggregate_results.py validate <audit_dir>`._\n"
+            )
+            continue
+        out.append(f"### {cid}\n")
+        # Embed the finding doc verbatim, indented under the section.
+        out.append(path.read_text(encoding="utf-8").strip())
+        out.append("\n")
+    return "\n".join(out)
+
+
+def render_remediation_plan(summary: dict[str, Any]) -> str:
+    findings = summary.get("findings", {})
+    details = findings.get("details", [])
+    out = ["## 6. Remediation-Plan\n"]
+    if not details:
+        out.append("_Keine Findings._\n")
+        return "\n".join(out)
+    sev_idx = {s: i for i, s in enumerate(SEVERITY_ORDER)}
+    sorted_details = sorted(
+        details,
+        key=lambda d: (
+            sev_idx.get(d.get("severity", "low"), 99),
+            d.get("category", ""),
+            d.get("check_id", ""),
+        ),
+    )
+    out.append("### Empfohlene Reihenfolge\n")
+    for i, d in enumerate(sorted_details, start=1):
+        out.append(
+            f"{i}. **{d.get('check_id')}** "
+            f"({d.get('severity')}, {d.get('status')})"
+        )
+    out.append("")
+    return "\n".join(out)
+
+
+def render_metadata(summary: dict[str, Any]) -> str:
+    meta = summary.get("audit_meta", {})
+    out = ["## 7. Audit-Metadata\n"]
+    out.append("| Feld | Wert |")
+    out.append("|---|---|")
+    for key in (
+        "skill_version", "catalog_version", "applies_when_dsl_version",
+        "policy", "audit_date",
+    ):
+        if key in meta:
+            out.append(f"| {key} | `{meta[key]}` |")
+    out.append("")
+    return "\n".join(out)
+
+
+# ---------------------------------------------------------------------------
+# Main pipeline
+# ---------------------------------------------------------------------------
+
+def build_report(
+    summary: dict[str, Any],
+    profile: dict[str, Any],
+    findings_dir: Path,
+) -> str:
+    server = summary.get("audit_meta", {}).get("server_name", "<server>")
+    audit_date = summary.get("audit_meta", {}).get("audit_date", "")
+    parts = [
+        f"# MCP-Server Audit-Report — `{server}`\n",
+        f"**Audit-Datum:** {audit_date}",
+        f"**Skill-Version:** {summary.get('audit_meta', {}).get('skill_version', '?')}",
+        f"**Catalog-Version:** {summary.get('audit_meta', {}).get('catalog_version', '?')}",
+        "",
+        "---",
+        "",
+        render_executive_summary(summary),
+        "---",
+        "",
+        render_profile_snapshot(summary, profile),
+        "---",
+        "",
+        render_applicability(summary),
+        "---",
+        "",
+        render_findings_table(summary),
+        "---",
+        "",
+        render_detail_findings(summary, findings_dir),
+        "---",
+        "",
+        render_remediation_plan(summary),
+        "---",
+        "",
+        render_metadata(summary),
+        "",
+        "_Generated by tools/build_report.py — do not edit by hand._",
+        "",
+    ]
+    return "\n".join(parts)
+
+
+def main(argv: list[str] | None = None) -> int:
+    force_utf8_stdio()
+    parser = argparse.ArgumentParser(
+        prog="build_report",
+        description=(
+            "Render audit-report.md from summary.json and findings/. "
+            "Replaces inline Python heredocs in SKILL Step 6."
+        ),
+    )
+    parser.add_argument(
+        "audit_dir",
+        help="Path to the audit directory containing summary.json and findings/",
+    )
+    parser.add_argument(
+        "--summary",
+        default=None,
+        help="Override summary.json path (default: <audit_dir>/summary.json)",
+    )
+    parser.add_argument(
+        "--findings-dir",
+        default=None,
+        help="Override findings dir (default: <audit_dir>/findings)",
+    )
+    parser.add_argument(
+        "--profile",
+        default=None,
+        help="Optional path to profile YAML/JSON for the snapshot section",
+    )
+    parser.add_argument(
+        "--out",
+        default=None,
+        help="Output path for report (default: <audit_dir>/audit-report.md)",
+    )
+    args = parser.parse_args(argv)
+
+    audit_dir = Path(args.audit_dir)
+    summary_path = Path(args.summary) if args.summary else audit_dir / "summary.json"
+    findings_dir = (
+        Path(args.findings_dir) if args.findings_dir else audit_dir / "findings"
+    )
+    out_path = Path(args.out) if args.out else audit_dir / "audit-report.md"
+    profile_path = Path(args.profile) if args.profile else None
+
+    if not summary_path.exists():
+        print(f"Error: {summary_path} not found", file=sys.stderr)
+        return 2
+
+    summary = _load_summary(summary_path)
+    profile = _load_profile(profile_path)
+    report = build_report(summary, profile, findings_dir)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(report, encoding="utf-8")
+    print(f"Report written to {out_path} ({len(report)} chars)")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    sys.exit(main())

--- a/tools/parse_catalog.py
+++ b/tools/parse_catalog.py
@@ -1,0 +1,195 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Parse the check catalog (checks/*.md frontmatter) into structured data.
+
+Replaces the inline awk/heredoc loops that the slash command and Step 2 of
+the SKILL workflow used to generate ad-hoc — the original audit run on
+Windows hit Bash quoting crashes when those heredocs got too clever
+(issue #11). This module is the canonical replacement.
+
+Usage:
+    python tools/parse_catalog.py             # JSON to stdout
+    python tools/parse_catalog.py --format table
+    python tools/parse_catalog.py --format manifest-check
+    python tools/parse_catalog.py --checks-dir path/to/checks
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+# Make `tools.*` importable when this script is invoked directly
+# (e.g. `python tools/parse_catalog.py`) and not as part of a package.
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from tools.eval_applicability import parse_check_frontmatter  # noqa: E402
+from tools.path_utils import force_utf8_stdio  # noqa: E402
+
+
+REQUIRED_FIELDS = ("id", "title", "category", "severity", "applies_when")
+
+
+def _default_checks_dir() -> Path:
+    return Path(__file__).resolve().parent.parent / "checks"
+
+
+def list_check_files(checks_dir: Path) -> list[Path]:
+    """All `*.md` files in checks_dir, sorted by stem.
+
+    MANIFEST.txt is intentionally not a `.md` so it isn't picked up.
+    """
+    return sorted(p for p in checks_dir.glob("*.md") if p.is_file())
+
+
+def parse_catalog(checks_dir: Path) -> dict[str, dict[str, Any]]:
+    """Parse every check file into a frontmatter dict, keyed by check ID.
+
+    Raises ValueError if two files declare the same `id` or if a file is
+    missing required fields.
+    """
+    catalog: dict[str, dict[str, Any]] = {}
+    for path in list_check_files(checks_dir):
+        fm = parse_check_frontmatter(path)
+        cid = fm.get("id") or path.stem
+        missing = [f for f in REQUIRED_FIELDS if not fm.get(f)]
+        if missing:
+            raise ValueError(
+                f"{path.name}: frontmatter missing required field(s) {missing}"
+            )
+        if cid in catalog:
+            raise ValueError(
+                f"Duplicate check id {cid!r} in {path.name} "
+                f"(also in {catalog[cid].get('_source')})"
+            )
+        fm["_source"] = path.name
+        catalog[cid] = fm
+    return catalog
+
+
+def manifest_check(checks_dir: Path) -> dict[str, Any]:
+    """Compare MANIFEST.txt against parsed catalog. Returns a diff report.
+
+    The manifest is the authoritative list of catalog IDs; the goal of
+    this check is to detect drift (missing files, orphan files, etc).
+    """
+    manifest_path = checks_dir / "MANIFEST.txt"
+    if not manifest_path.exists():
+        raise FileNotFoundError(f"{manifest_path} not found")
+    manifest_ids = [
+        line.strip()
+        for line in manifest_path.read_text(encoding="utf-8").splitlines()
+        if line.strip() and not line.strip().startswith("#")
+    ]
+    catalog = parse_catalog(checks_dir)
+    catalog_ids = list(catalog.keys())
+    in_manifest_only = sorted(set(manifest_ids) - set(catalog_ids))
+    in_catalog_only = sorted(set(catalog_ids) - set(manifest_ids))
+    return {
+        "manifest_count": len(manifest_ids),
+        "catalog_count": len(catalog_ids),
+        "consistent": not (in_manifest_only or in_catalog_only),
+        "in_manifest_only": in_manifest_only,
+        "in_catalog_only": in_catalog_only,
+    }
+
+
+def category_counts(catalog: dict[str, dict[str, Any]]) -> dict[str, int]:
+    counts: dict[str, int] = {}
+    for fm in catalog.values():
+        cat = fm.get("category", "?")
+        counts[cat] = counts.get(cat, 0) + 1
+    return dict(sorted(counts.items()))
+
+
+def severity_counts(catalog: dict[str, dict[str, Any]]) -> dict[str, int]:
+    counts: dict[str, int] = {}
+    for fm in catalog.values():
+        sev = fm.get("severity", "?")
+        counts[sev] = counts.get(sev, 0) + 1
+    return dict(sorted(counts.items()))
+
+
+def _print_table(catalog: dict[str, dict[str, Any]]) -> None:
+    print(f"{'ID':<14} {'CAT':<6} {'SEV':<10} APPLIES_WHEN")
+    for cid, fm in catalog.items():
+        print(
+            f"{cid:<14} "
+            f"{fm.get('category', '?'):<6} "
+            f"{fm.get('severity', '?'):<10} "
+            f"{fm.get('applies_when', '?')}"
+        )
+    print()
+    print(f"Total: {len(catalog)} checks")
+    print(f"By category: {category_counts(catalog)}")
+    print(f"By severity: {severity_counts(catalog)}")
+
+
+def main(argv: list[str] | None = None) -> int:
+    force_utf8_stdio()
+    parser = argparse.ArgumentParser(
+        prog="parse_catalog",
+        description=(
+            "Parse the check catalog into structured data. Replaces the "
+            "ad-hoc awk/heredoc loops that the SKILL Step 2 used to "
+            "generate during audit runs."
+        ),
+    )
+    parser.add_argument(
+        "--checks-dir",
+        default=str(_default_checks_dir()),
+        help="Directory containing check markdown files",
+    )
+    parser.add_argument(
+        "--format",
+        choices=("json", "table", "manifest-check"),
+        default="json",
+        help="Output format",
+    )
+    parser.add_argument(
+        "--out",
+        default=None,
+        help="Write output to file instead of stdout",
+    )
+    args = parser.parse_args(argv)
+
+    checks_dir = Path(args.checks_dir)
+    if not checks_dir.is_dir():
+        print(f"Error: {checks_dir} is not a directory", file=sys.stderr)
+        return 2
+
+    if args.format == "manifest-check":
+        report = manifest_check(checks_dir)
+        text = json.dumps(report, indent=2, ensure_ascii=False)
+        if args.out:
+            Path(args.out).write_text(text + "\n", encoding="utf-8")
+        else:
+            print(text)
+        return 0 if report["consistent"] else 1
+
+    catalog = parse_catalog(checks_dir)
+
+    if args.format == "json":
+        text = json.dumps(catalog, indent=2, ensure_ascii=False)
+        if args.out:
+            Path(args.out).write_text(text + "\n", encoding="utf-8")
+        else:
+            print(text)
+        return 0
+
+    if args.format == "table":
+        if args.out:
+            print(f"--out is not supported with --format table", file=sys.stderr)
+            return 2
+        _print_table(catalog)
+        return 0
+
+    return 2
+
+
+if __name__ == "__main__":  # pragma: no cover
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Closes #11.

The first real audit (`srgssr-mcp`, 2026-04-30) had Claude generate inline Python heredocs for catalog parsing and report rendering. Both crashed on Windows Git Bash with quoting errors. This PR provides dedicated helper scripts so the agent never has to invent ad-hoc parsers again.

## What changed

### `tools/parse_catalog.py` — replaces awk frontmatter loops
- Parses every `checks/*.md` frontmatter into structured data.
- CLI: `--format {json,table,manifest-check}`.
- `manifest-check` validates `MANIFEST.txt` against `*.md` files; exits 1 on drift (missing or orphan IDs).
- Hard-enforces required fields (`id`, `title`, `category`, `severity`, `applies_when`); rejects duplicate IDs.

### `tools/build_report.py` — replaces inline Python report rendering
- Renders `audit-report.md` from `summary.json` + `findings/` + optional profile.
- Seven mandatory sections (executive summary, profile snapshot, applicability, findings table, detail findings, remediation plan, metadata).
- Findings sorted by severity (critical → low). Missing finding docs are explicitly flagged in the report itself.

### Bug fix: standalone-script bootstrap
`aggregate_results.py` and `parse_catalog.py` both fell over with `ModuleNotFoundError: No module named 'tools'` when invoked as `python tools/X.py`. Tests didn't catch it because `tests/conftest.py` adds REPO_ROOT for pytest. Both scripts now insert REPO_ROOT into `sys.path` before package-style imports.

### Documentation
- **SKILL.md Step 0.3**: inline heredocs are now explicitly forbidden. Table maps every common task to its helper-script invocation.
- **`.claude/commands/audit-mcp.md`** Step 2 + Step 6: rewritten to call helper scripts. `python` and `python3` added to `allowed-tools`.

## Test plan

- [x] `python -m pytest tests/` — 139 passed (103 → 139, +36 cases)
- [x] `python tools/parse_catalog.py --format manifest-check` — exit 0, all 68 checks consistent
- [x] `python tools/parse_catalog.py --format table` — clean output, correct category/severity counts
- [x] `python tools/build_report.py <dir>` — produces well-formed audit-report.md
- [x] `python tools/aggregate_results.py --help` — works standalone (was broken before this PR)
- [ ] CI green on Ubuntu + Windows runners

## Out of scope (separate PRs)

- #12 — Validate Task-agent results before continuing
- #13 — `write_access` vs. `write_capable` schema migration
- #14 — Profile placeholder detection
- #15 — Audit run-id with timezone
- #16 — Migrate the 9 broken `applies_when` expressions


---
_Generated by [Claude Code](https://claude.ai/code/session_01PgYtwRK14HmFwES2PusuHH)_