### PR TITLE
Task-agent validation gate + run logging (closes #12)

### DIFF
--- a/.claude/commands/audit-mcp.md
+++ b/.claude/commands/audit-mcp.md
@@ -177,7 +177,25 @@ Lies pro anwendbarem Check das Check-File und identifiziere die Verification-Mod
 
 Speichere die rohen Befehl-Outputs pro Check in `$OUTPUT_DIR/raw/<check-id>.txt` für Audit-Trail.
 
-**Output Schritt 4:** Tabelle aller anwendbaren Checks mit Status (Pass/Fail/Partial/TODO). Plus Anzahl-Aufschlüsselung.
+**Pflicht-Gate bei Task-Agent-Delegation:** Wenn du einen Task-Agent aufrufst, um mehrere Checks parallel abzuarbeiten, MUSST du nach dem Aufruf verifizieren, dass alle erwarteten Files persistiert wurden. Hintergrund: Im ersten realen Audit hat ein Agent stillschweigend mit 0 Tokens zurückgegeben — der Skill hat das nicht gemerkt.
+
+```bash
+# Nach jedem Task-Agent-Aufruf:
+python "$SKILL_BASE/tools/verify_raw_outputs.py" "$OUTPUT_DIR/raw/" \
+    --expected-ids "$AGENT_BATCH_IDS" --min-bytes 1
+# exit 0 = vollständig, exit 1 = unvollständig (siehe incomplete_ids im JSON)
+
+# Run-Metadata loggen — Tool-Use-Count, Token-Count, Duration:
+python "$SKILL_BASE/tools/agent_run_log.py" log \
+    --meta-path "$OUTPUT_DIR/audit-meta.json" \
+    --tool-uses "$AGENT_TOOL_USES" --tokens "$AGENT_TOKENS" \
+    --duration "$AGENT_DURATION_SEC" \
+    --expected "$AGENT_BATCH_IDS" --raw-dir "$OUTPUT_DIR/raw/"
+```
+
+**Retry-Policy:** Bei `incomplete_ids` oder `empty`-Status (0 Tokens) wiederhole nur die fehlenden IDs, max. 2 Retries (`--retry-of <run_index>` mitgeben). Nach 2 Retries: harter Abbruch mit Liste der unfertigen IDs.
+
+**Output Schritt 4:** Tabelle aller anwendbaren Checks mit Status (Pass/Fail/Partial/TODO). Plus Anzahl-Aufschlüsselung. Plus `agent_run_log.py summary` zur Bestätigung dass `overall_status == "ok"`.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ Versionierung: [Semantic Versioning](https://semver.org/lang/de/).
 
 ## [Unreleased]
 
+### Hinzugefügt — Task-Agent-Validation-Gate (Issue #12)
+
+Im ersten realen Audit hat ein Task-Agent mit `Done (68 tool uses · 0 tokens · 2m 20s)` zurückgegeben — vollständiger stiller Fehlschlag. Der Skill hat das nicht erkannt, Claude hat manuell weitergemacht und das Problem ad hoc kompensiert. Bei einem unbeaufsichtigten Audit wäre das stiller Datenverlust gewesen.
+
+- **`tools/verify_raw_outputs.py`** — verifiziert, dass alle erwarteten Check-IDs eine nicht-leere Output-Datei in `raw/` haben. Catches die Empty-Placeholder-Files via `--min-bytes`-Threshold. Exit 0/1/2.
+- **`tools/agent_run_log.py`** — appendet pro Task-Agent-Aufruf einen Eintrag in `audit-meta.json` mit Tool-Uses, Tokens, Duration, Expected/Satisfied/Incomplete-IDs und einer 3-State-Klassifikation (`ok`/`empty`/`incomplete`). `summary`-Subcommand gibt Coverage-Aggregate.
+- **Drei-State-Klassifikation** — `empty` (Tokens=0, hard fail), `incomplete` (Tokens > 0 aber IDs fehlen), `ok`. Empty hat Vorrang, weil 0 Tokens immer auf einen Agent-Fehlschlag hindeutet.
+- **Retry-Policy in SKILL.md Step 4.5** — bei `incomplete`/`empty` max. 2 Retries nur für die fehlenden IDs (`--retry-of <run_index>`-Kette in audit-meta.json). Danach harter Abbruch.
+- **37 neue pytest cases** — `tests/test_verify_raw_outputs.py` (14) + `tests/test_agent_run_log.py` (23). Test-Total: 139 → 176.
+- **SKILL.md Step 0.3 erweitert** — Tabelle der Helper-Scripts um Verifier + Logger ergänzt.
+- **Slash-Command Step 4 erweitert** — Pflicht-Gate dokumentiert.
+
 ### Hinzugefügt — Catalog-Parser und Report-Builder (Issue #11)
 
 Inline-Heredocs sind jetzt vollständig durch dedizierte Helper-Scripts ersetzt. Im ersten realen Audit wurden Inline-Python-Blöcke ad hoc generiert, was auf Windows Git Bash mehrfach an Quoting gecrasht ist.

--- a/SKILL.md
+++ b/SKILL.md
@@ -73,6 +73,8 @@ Inline-`python3 << 'PYEOF'`-Blöcke crashen auf Windows Git Bash regelmässig du
 | Verification-Results aggregieren | `python tools/aggregate_results.py aggregate results.json --out summary.json` |
 | Findings-Set vs. Disk validieren | `python tools/aggregate_results.py validate <audit_dir>` |
 | Audit-Report generieren | `python tools/build_report.py <audit_dir>` |
+| Task-Agent-Output verifizieren | `python tools/verify_raw_outputs.py raw/ --expected-ids ID1,ID2` |
+| Task-Agent-Run loggen | `python tools/agent_run_log.py log --meta-path audit-meta.json ...` |
 | Pfad zu Native/POSIX konvertieren | `python tools/path_utils.py to-native <path>` |
 
 Wenn ein Audit ein Snippet braucht das hier nicht abgedeckt ist: erst Issue im Skill-Repo öffnen, dann Helper-Script bauen, dann verwenden. **Inline-Heredoc ist der Anti-Pattern, der nicht-reproduzierbare Audits erzeugt.**
@@ -285,6 +287,43 @@ Ein Check besteht **nur dann** als `pass`, wenn:
 - Keine `gaps` der Severity ≥ Check-Severity vorliegen
 
 Sonst: `partial` (wenn 50%+ erfüllt) oder `fail`.
+
+### 4.5 Task-Agent-Validation-Gate (verbindlich)
+
+Wenn die Check-Execution per Task-Agent delegiert wird (typisch bei Batch-Verarbeitung mehrerer Checks gleichzeitig), MUSS nach jedem Agent-Aufruf ein Verifikations-Gate laufen. Hintergrund: Im ersten realen Audit hat ein Task-Agent mit `Done (68 tool uses · 0 tokens · 2m 20s)` zurückgegeben — vollständiger stiller Fehlschlag — und der Skill hat das nicht erkannt.
+
+```bash
+# 1. Nach jedem Task-Agent-Aufruf: prüfen, dass alle erwarteten raw/-Files
+#    existieren UND nicht leer sind (catches the 0-token failure mode).
+python "$SKILL_BASE/tools/verify_raw_outputs.py" "$OUTPUT_DIR/raw/" \
+    --expected-ids ARCH-001,ARCH-002,SEC-021 \
+    --min-bytes 1
+
+# 2. Run-Metadata loggen — Tool-Uses, Tokens, Duration in audit-meta.json.
+#    Dieser Befehl exitet 1 wenn der Agent als `empty` oder `incomplete`
+#    klassifiziert wird.
+python "$SKILL_BASE/tools/agent_run_log.py" log \
+    --meta-path "$OUTPUT_DIR/audit-meta.json" \
+    --tool-uses 73 --tokens 108100 --duration 640 \
+    --expected ARCH-001,ARCH-002,SEC-021 \
+    --raw-dir "$OUTPUT_DIR/raw/"
+```
+
+**Retry-Policy bei Fehlschlag:**
+
+1. **Erster Aufruf** — alle anwendbaren Checks erwartet
+2. **Bei `incomplete_ids`** → erneuter Task-Agent-Aufruf nur mit den fehlenden IDs, Logging mit `--retry-of <run_index>`
+3. **Bei `empty`-Status (Tokens=0)** → identisch behandeln, der Aufruf zählt nicht als ausgeführt
+4. **Maximal 2 Retries.** Danach harter Abbruch mit der Liste der unfertigen IDs — der menschliche Auditor muss diese Checks manuell ausführen oder den Audit verschieben
+
+```bash
+# Am Ende von Step 4: Coverage-Summary
+python "$SKILL_BASE/tools/agent_run_log.py" summary \
+    --meta-path "$OUTPUT_DIR/audit-meta.json"
+# overall_status muss "ok" sein, sonst Step 5 nicht starten
+```
+
+Dieses Gate gilt nicht bei Single-Check-Bash-Aufrufen (kein Task-Agent involviert) — dort liefert die Bash-Pipeline ihren eigenen Exit-Code.
 
 ---
 

--- a/tests/test_agent_run_log.py
+++ b/tests/test_agent_run_log.py
@@ -1,0 +1,283 @@
+# -*- coding: utf-8 -*-
+"""Tests for tools/agent_run_log.py — Task-agent run logging."""
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+from tools.agent_run_log import (
+    _classify_run,
+    append_run,
+    load_meta,
+    main,
+    save_meta,
+    summarise,
+)
+
+
+# ---------------------------------------------------------------------------
+# Classification logic — locks in the failure-mode taxonomy
+# ---------------------------------------------------------------------------
+
+class TestClassifyRun:
+    def test_ok_when_tokens_and_no_incomplete(self):
+        assert _classify_run(tokens=10000, incomplete_ids=[]) == "ok"
+
+    def test_empty_when_zero_tokens(self):
+        # The exact failure mode from issue #12.
+        assert _classify_run(tokens=0, incomplete_ids=[]) == "empty"
+
+    def test_empty_takes_precedence_over_incomplete(self):
+        # 0 tokens AND missing IDs → still classified as empty
+        assert _classify_run(tokens=0, incomplete_ids=["X-1"]) == "empty"
+
+    def test_incomplete_when_tokens_but_missing(self):
+        assert _classify_run(tokens=5000, incomplete_ids=["X-1"]) == "incomplete"
+
+
+# ---------------------------------------------------------------------------
+# append_run — fixture-driven scenarios
+# ---------------------------------------------------------------------------
+
+class TestAppendRun:
+    def _setup_raw(self, tmp_path: Path, present: list[str]) -> Path:
+        raw = tmp_path / "raw"
+        raw.mkdir()
+        for cid in present:
+            (raw / f"{cid}.txt").write_text("ok", encoding="utf-8")
+        return raw
+
+    def test_ok_run(self, tmp_path):
+        raw = self._setup_raw(tmp_path, ["ARCH-001", "SEC-021"])
+        meta = {"audit_meta": {}, "agent_runs": []}
+        entry = append_run(
+            meta,
+            tool_uses=44, tokens=85100, duration_seconds=372.3,
+            expected_ids=["ARCH-001", "SEC-021"],
+            raw_dir=raw,
+        )
+        assert entry["status"] == "ok"
+        assert entry["satisfied_ids"] == ["ARCH-001", "SEC-021"]
+        assert entry["incomplete_ids"] == []
+        assert meta["agent_runs"][0] is entry
+
+    def test_empty_run_zero_tokens(self, tmp_path):
+        # The bug from issue #12: 0 tokens, no files written.
+        raw = self._setup_raw(tmp_path, [])
+        meta = {"audit_meta": {}, "agent_runs": []}
+        entry = append_run(
+            meta,
+            tool_uses=68, tokens=0, duration_seconds=140,
+            expected_ids=["ARCH-001"],
+            raw_dir=raw,
+        )
+        assert entry["status"] == "empty"
+        assert entry["incomplete_ids"] == ["ARCH-001"]
+
+    def test_incomplete_partial_coverage(self, tmp_path):
+        raw = self._setup_raw(tmp_path, ["ARCH-001"])
+        meta = {"audit_meta": {}, "agent_runs": []}
+        entry = append_run(
+            meta,
+            tool_uses=20, tokens=30000, duration_seconds=90,
+            expected_ids=["ARCH-001", "SEC-021", "OPS-001"],
+            raw_dir=raw,
+        )
+        assert entry["status"] == "incomplete"
+        assert entry["satisfied_ids"] == ["ARCH-001"]
+        assert sorted(entry["incomplete_ids"]) == ["OPS-001", "SEC-021"]
+
+    def test_run_index_increments(self, tmp_path):
+        raw = self._setup_raw(tmp_path, ["X-1"])
+        meta = {"audit_meta": {}, "agent_runs": []}
+        e1 = append_run(meta, tool_uses=1, tokens=1, duration_seconds=1,
+                        expected_ids=["X-1"], raw_dir=raw)
+        e2 = append_run(meta, tool_uses=1, tokens=1, duration_seconds=1,
+                        expected_ids=["X-1"], raw_dir=raw)
+        assert e1["run_index"] == 0
+        assert e2["run_index"] == 1
+
+    def test_retry_link_recorded(self, tmp_path):
+        raw = self._setup_raw(tmp_path, ["X-1"])
+        meta = {"audit_meta": {}, "agent_runs": []}
+        append_run(meta, tool_uses=1, tokens=0, duration_seconds=1,
+                   expected_ids=["X-1"], raw_dir=raw)
+        retry = append_run(
+            meta, tool_uses=2, tokens=5000, duration_seconds=10,
+            expected_ids=["X-1"], raw_dir=raw,
+            retry_of_run_index=0,
+        )
+        assert retry["retry_of_run_index"] == 0
+
+    def test_started_at_iso_format(self, tmp_path):
+        raw = self._setup_raw(tmp_path, ["X-1"])
+        meta = {"audit_meta": {}, "agent_runs": []}
+        fixed = datetime(2026, 5, 2, 7, 15, 0, tzinfo=timezone.utc)
+        entry = append_run(
+            meta, tool_uses=1, tokens=1, duration_seconds=1,
+            expected_ids=["X-1"], raw_dir=raw, started_at=fixed,
+        )
+        assert entry["started_at"] == "2026-05-02T07:15:00+00:00"
+
+
+# ---------------------------------------------------------------------------
+# Persistence + summarise
+# ---------------------------------------------------------------------------
+
+class TestPersistence:
+    def test_load_missing_file_returns_empty_skeleton(self, tmp_path):
+        meta = load_meta(tmp_path / "audit-meta.json")
+        assert meta == {"audit_meta": {}, "agent_runs": []}
+
+    def test_save_then_load_round_trip(self, tmp_path):
+        path = tmp_path / "audit-meta.json"
+        meta = {"audit_meta": {"server_name": "x"}, "agent_runs": [{"a": 1}]}
+        save_meta(path, meta)
+        loaded = load_meta(path)
+        assert loaded == meta
+
+    def test_load_rejects_non_object(self, tmp_path):
+        path = tmp_path / "audit-meta.json"
+        path.write_text("[]", encoding="utf-8")
+        with pytest.raises(ValueError, match="top level must be an object"):
+            load_meta(path)
+
+
+class TestSummarise:
+    def test_no_runs(self):
+        assert summarise({"audit_meta": {}, "agent_runs": []})["status"] == "no-runs"
+
+    def test_single_ok_run(self, tmp_path):
+        raw = tmp_path / "raw"
+        raw.mkdir()
+        (raw / "X-1.txt").write_text("ok", encoding="utf-8")
+        meta = {"audit_meta": {}, "agent_runs": []}
+        append_run(meta, tool_uses=10, tokens=5000, duration_seconds=30,
+                   expected_ids=["X-1"], raw_dir=raw)
+        s = summarise(meta)
+        assert s["overall_status"] == "ok"
+        assert s["had_retries"] is False
+        assert s["expected_unique_ids"] == 1
+
+    def test_retry_completes_coverage(self, tmp_path):
+        raw = tmp_path / "raw"
+        raw.mkdir()
+        meta = {"audit_meta": {}, "agent_runs": []}
+        # First run: empty failure
+        append_run(meta, tool_uses=10, tokens=0, duration_seconds=30,
+                   expected_ids=["X-1"], raw_dir=raw)
+        # Now Task-agent retry writes the missing file
+        (raw / "X-1.txt").write_text("ok", encoding="utf-8")
+        append_run(meta, tool_uses=5, tokens=8000, duration_seconds=20,
+                   expected_ids=["X-1"], raw_dir=raw, retry_of_run_index=0)
+        s = summarise(meta)
+        assert s["overall_status"] == "ok"
+        assert s["had_retries"] is True
+        assert s["runs"] == 2
+
+    def test_aggregate_arithmetic(self, tmp_path):
+        raw = tmp_path / "raw"
+        raw.mkdir()
+        (raw / "X-1.txt").write_text("ok", encoding="utf-8")
+        meta = {"audit_meta": {}, "agent_runs": []}
+        append_run(meta, tool_uses=10, tokens=1000, duration_seconds=5,
+                   expected_ids=["X-1"], raw_dir=raw)
+        append_run(meta, tool_uses=20, tokens=2000, duration_seconds=15,
+                   expected_ids=["X-1"], raw_dir=raw)
+        s = summarise(meta)
+        assert s["total_tokens"] == 3000
+        assert s["total_tool_uses"] == 30
+        assert s["total_duration_seconds"] == 20.0
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+class TestCli:
+    def _setup(self, tmp_path: Path) -> tuple[Path, Path]:
+        raw = tmp_path / "raw"
+        raw.mkdir()
+        meta = tmp_path / "audit-meta.json"
+        return raw, meta
+
+    def test_cli_log_ok_returns_zero(self, tmp_path):
+        raw, meta = self._setup(tmp_path)
+        (raw / "X-1.txt").write_text("ok", encoding="utf-8")
+        rc = main([
+            "log",
+            "--meta-path", str(meta),
+            "--tool-uses", "10",
+            "--tokens", "5000",
+            "--duration", "30",
+            "--expected", "X-1",
+            "--raw-dir", str(raw),
+        ])
+        assert rc == 0
+        data = json.loads(meta.read_text(encoding="utf-8"))
+        assert data["agent_runs"][0]["status"] == "ok"
+
+    def test_cli_log_empty_returns_one(self, tmp_path):
+        raw, meta = self._setup(tmp_path)
+        # No files written, 0 tokens → empty status
+        rc = main([
+            "log",
+            "--meta-path", str(meta),
+            "--tool-uses", "68",
+            "--tokens", "0",
+            "--duration", "140",
+            "--expected", "X-1",
+            "--raw-dir", str(raw),
+        ])
+        assert rc == 1
+        data = json.loads(meta.read_text(encoding="utf-8"))
+        assert data["agent_runs"][0]["status"] == "empty"
+
+    def test_cli_log_appends_not_overwrites(self, tmp_path):
+        raw, meta = self._setup(tmp_path)
+        (raw / "X-1.txt").write_text("ok", encoding="utf-8")
+        for _ in range(3):
+            main([
+                "log",
+                "--meta-path", str(meta),
+                "--tool-uses", "1", "--tokens", "1", "--duration", "1",
+                "--expected", "X-1", "--raw-dir", str(raw),
+            ])
+        data = json.loads(meta.read_text(encoding="utf-8"))
+        assert len(data["agent_runs"]) == 3
+        assert [r["run_index"] for r in data["agent_runs"]] == [0, 1, 2]
+
+    def test_cli_log_with_retry_of(self, tmp_path):
+        raw, meta = self._setup(tmp_path)
+        (raw / "X-1.txt").write_text("ok", encoding="utf-8")
+        main([
+            "log", "--meta-path", str(meta),
+            "--tool-uses", "1", "--tokens", "1", "--duration", "1",
+            "--expected", "X-1", "--raw-dir", str(raw),
+        ])
+        main([
+            "log", "--meta-path", str(meta),
+            "--tool-uses", "1", "--tokens", "1", "--duration", "1",
+            "--expected", "X-1", "--raw-dir", str(raw),
+            "--retry-of", "0",
+        ])
+        data = json.loads(meta.read_text(encoding="utf-8"))
+        assert data["agent_runs"][1]["retry_of_run_index"] == 0
+
+    def test_cli_summary(self, tmp_path):
+        raw, meta = self._setup(tmp_path)
+        (raw / "X-1.txt").write_text("ok", encoding="utf-8")
+        main([
+            "log", "--meta-path", str(meta),
+            "--tool-uses", "1", "--tokens", "1", "--duration", "1",
+            "--expected", "X-1", "--raw-dir", str(raw),
+        ])
+        rc = main(["summary", "--meta-path", str(meta)])
+        assert rc == 0
+
+    def test_cli_summary_missing_file_returns_two(self, tmp_path):
+        rc = main(["summary", "--meta-path", str(tmp_path / "nope.json")])
+        assert rc == 2

--- a/tests/test_verify_raw_outputs.py
+++ b/tests/test_verify_raw_outputs.py
@@ -1,0 +1,166 @@
+# -*- coding: utf-8 -*-
+"""Tests for tools/verify_raw_outputs.py."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from tools.verify_raw_outputs import main, verify_raw_outputs
+
+
+# ---------------------------------------------------------------------------
+# Pure verification function
+# ---------------------------------------------------------------------------
+
+class TestVerify:
+    def _write(self, dir: Path, name: str, content: str = "ok") -> Path:
+        path = dir / name
+        path.write_text(content, encoding="utf-8")
+        return path
+
+    def test_all_satisfied(self, tmp_path):
+        self._write(tmp_path, "ARCH-001.txt", "result")
+        self._write(tmp_path, "SEC-021.txt", "result")
+        report = verify_raw_outputs(tmp_path, ["ARCH-001", "SEC-021"])
+        assert report["consistent"] is True
+        assert report["satisfied"] == ["ARCH-001", "SEC-021"]
+        assert report["missing"] == []
+        assert report["empty"] == []
+        assert report["incomplete_ids"] == []
+
+    def test_missing_file(self, tmp_path):
+        self._write(tmp_path, "ARCH-001.txt", "ok")
+        report = verify_raw_outputs(tmp_path, ["ARCH-001", "MISSING-001"])
+        assert report["consistent"] is False
+        assert report["missing"] == ["MISSING-001"]
+        assert report["incomplete_ids"] == ["MISSING-001"]
+
+    def test_empty_file_below_threshold(self, tmp_path):
+        # Silent-failure mode from the original audit: 0-token run writes
+        # an empty placeholder file.
+        self._write(tmp_path, "ARCH-001.txt", "")
+        report = verify_raw_outputs(tmp_path, ["ARCH-001"], min_bytes=1)
+        assert report["consistent"] is False
+        assert report["empty"] == ["ARCH-001"]
+        assert report["incomplete_ids"] == ["ARCH-001"]
+
+    def test_min_bytes_strict(self, tmp_path):
+        # File has 5 bytes but threshold is 10
+        self._write(tmp_path, "ARCH-001.txt", "abcde")
+        report = verify_raw_outputs(tmp_path, ["ARCH-001"], min_bytes=10)
+        assert report["consistent"] is False
+        assert report["empty"] == ["ARCH-001"]
+
+    def test_mixed_outcomes(self, tmp_path):
+        self._write(tmp_path, "ARCH-001.txt", "good")  # satisfied
+        self._write(tmp_path, "SEC-021.txt", "")       # empty
+        # ARCH-002 not written → missing
+        report = verify_raw_outputs(
+            tmp_path, ["ARCH-001", "ARCH-002", "SEC-021"]
+        )
+        assert report["satisfied"] == ["ARCH-001"]
+        assert report["missing"] == ["ARCH-002"]
+        assert report["empty"] == ["SEC-021"]
+        assert report["incomplete_ids"] == ["ARCH-002", "SEC-021"]
+        assert report["consistent"] is False
+
+    def test_nonexistent_dir(self, tmp_path):
+        report = verify_raw_outputs(
+            tmp_path / "missing", ["ARCH-001"]
+        )
+        assert report["consistent"] is False
+        assert "error" in report
+        assert report["incomplete_ids"] == ["ARCH-001"]
+
+    def test_custom_suffix(self, tmp_path):
+        self._write(tmp_path, "ARCH-001.json", '{"x": 1}')
+        report = verify_raw_outputs(
+            tmp_path, ["ARCH-001"], suffix=".json"
+        )
+        assert report["consistent"] is True
+
+    def test_empty_expected_list(self, tmp_path):
+        report = verify_raw_outputs(tmp_path, [])
+        assert report["consistent"] is True
+        assert report["satisfied"] == []
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+class TestCli:
+    def _setup(self, tmp_path: Path, ids_present: list[str]) -> Path:
+        raw = tmp_path / "raw"
+        raw.mkdir()
+        for cid in ids_present:
+            (raw / f"{cid}.txt").write_text("data", encoding="utf-8")
+        return raw
+
+    def test_cli_all_satisfied_returns_zero(self, tmp_path, capsys):
+        raw = self._setup(tmp_path, ["ARCH-001", "SEC-021"])
+        rc = main([
+            str(raw),
+            "--expected-ids", "ARCH-001,SEC-021",
+        ])
+        assert rc == 0
+        out = json.loads(capsys.readouterr().out)
+        assert out["consistent"] is True
+
+    def test_cli_incomplete_returns_one(self, tmp_path, capsys):
+        raw = self._setup(tmp_path, ["ARCH-001"])
+        rc = main([
+            str(raw),
+            "--expected-ids", "ARCH-001,MISSING-001",
+        ])
+        assert rc == 1
+        out = json.loads(capsys.readouterr().out)
+        assert out["incomplete_ids"] == ["MISSING-001"]
+
+    def test_cli_expected_ids_file(self, tmp_path):
+        raw = self._setup(tmp_path, ["ARCH-001", "SEC-021"])
+        ids_file = tmp_path / "expected.txt"
+        ids_file.write_text(
+            "# expected ids\nARCH-001\nSEC-021\n# trailing comment\n",
+            encoding="utf-8",
+        )
+        rc = main([
+            str(raw),
+            "--expected-ids-file", str(ids_file),
+        ])
+        assert rc == 0
+
+    def test_cli_writes_out_file(self, tmp_path):
+        raw = self._setup(tmp_path, ["ARCH-001"])
+        out_path = tmp_path / "report.json"
+        rc = main([
+            str(raw),
+            "--expected-ids", "ARCH-001",
+            "--out", str(out_path),
+        ])
+        assert rc == 0
+        data = json.loads(out_path.read_text(encoding="utf-8"))
+        assert data["consistent"] is True
+
+    def test_cli_min_bytes_flag(self, tmp_path):
+        raw = tmp_path / "raw"
+        raw.mkdir()
+        (raw / "ARCH-001.txt").write_text("xx", encoding="utf-8")
+        # 2 bytes, threshold 10 → empty
+        rc = main([
+            str(raw),
+            "--expected-ids", "ARCH-001",
+            "--min-bytes", "10",
+        ])
+        assert rc == 1
+
+    def test_cli_missing_ids_file_returns_two(self, tmp_path):
+        raw = tmp_path / "raw"
+        raw.mkdir()
+        rc = main([
+            str(raw),
+            "--expected-ids-file", str(tmp_path / "nope.txt"),
+        ])
+        assert rc == 2

--- a/tools/agent_run_log.py
+++ b/tools/agent_run_log.py
@@ -1,0 +1,238 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Append Task-agent run metadata to audit-meta.json.
+
+Closes the audit-trail half of issue #12. Whenever the slash command
+delegates check execution to a Task-agent, the agent's tool-use count,
+token count, duration, and completion status get logged here. The audit
+report and the Notion-Sync can then surface "this audit had to retry
+SEC-021 twice" instead of pretending everything was clean.
+
+Schema (audit-meta.json):
+    {
+      "audit_meta": {
+        "server_name": "...",
+        "audit_date": "...",
+        "skill_version": "..."
+      },
+      "agent_runs": [
+        {
+          "run_index": 0,
+          "started_at": "2026-05-02T07:15:00+00:00",
+          "duration_seconds": 124,
+          "tool_uses": 73,
+          "tokens": 108100,
+          "expected_ids": ["ARCH-001", ...],
+          "satisfied_ids": ["ARCH-001", ...],
+          "incomplete_ids": ["SEC-021"],
+          "status": "ok" | "incomplete" | "empty",
+          "retry_of_run_index": null
+        },
+        ...
+      ]
+    }
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+# Bootstrap.
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from tools.path_utils import force_utf8_stdio  # noqa: E402
+from tools.verify_raw_outputs import verify_raw_outputs  # noqa: E402
+
+
+def _classify_run(
+    tokens: int,
+    incomplete_ids: list[str],
+) -> str:
+    """Three-state status:
+      ok          — every expected ID has a non-empty output
+      incomplete  — some IDs missing or below threshold
+      empty       — agent returned 0 tokens (silent failure mode from #12)
+    """
+    if tokens == 0:
+        return "empty"
+    if incomplete_ids:
+        return "incomplete"
+    return "ok"
+
+
+def load_meta(path: Path) -> dict[str, Any]:
+    if not path.exists():
+        return {"audit_meta": {}, "agent_runs": []}
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise ValueError(f"{path}: top level must be an object")
+    data.setdefault("audit_meta", {})
+    data.setdefault("agent_runs", [])
+    if not isinstance(data["agent_runs"], list):
+        raise ValueError(f"{path}: agent_runs must be a list")
+    return data
+
+
+def save_meta(path: Path, meta: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(meta, indent=2, ensure_ascii=False) + "\n",
+        encoding="utf-8",
+    )
+
+
+def append_run(
+    meta: dict[str, Any],
+    *,
+    tool_uses: int,
+    tokens: int,
+    duration_seconds: float,
+    expected_ids: list[str],
+    raw_dir: Path,
+    min_bytes: int = 1,
+    started_at: datetime | None = None,
+    retry_of_run_index: int | None = None,
+) -> dict[str, Any]:
+    """Append a structured run entry. Returns the entry that was added."""
+    started_at = started_at or datetime.now(timezone.utc)
+    verify = verify_raw_outputs(raw_dir, expected_ids, min_bytes=min_bytes)
+    status = _classify_run(tokens, verify["incomplete_ids"])
+    entry = {
+        "run_index": len(meta["agent_runs"]),
+        "started_at": started_at.isoformat(),
+        "duration_seconds": round(float(duration_seconds), 2),
+        "tool_uses": int(tool_uses),
+        "tokens": int(tokens),
+        "expected_ids": list(expected_ids),
+        "satisfied_ids": verify["satisfied"],
+        "missing_ids": verify["missing"],
+        "empty_ids": verify["empty"],
+        "incomplete_ids": verify["incomplete_ids"],
+        "status": status,
+        "retry_of_run_index": retry_of_run_index,
+    }
+    meta["agent_runs"].append(entry)
+    return entry
+
+
+def summarise(meta: dict[str, Any]) -> dict[str, Any]:
+    runs = meta.get("agent_runs", [])
+    if not runs:
+        return {"runs": 0, "status": "no-runs", "incomplete_ids": []}
+    total_tokens = sum(r.get("tokens", 0) for r in runs)
+    total_tool_uses = sum(r.get("tool_uses", 0) for r in runs)
+    total_duration = sum(r.get("duration_seconds", 0) for r in runs)
+
+    # Build coverage from union of satisfied across all runs (latest wins
+    # if an earlier run was incomplete and a later retry filled it).
+    satisfied: set[str] = set()
+    expected: set[str] = set()
+    for r in runs:
+        expected.update(r.get("expected_ids", []))
+        satisfied.update(r.get("satisfied_ids", []))
+    incomplete = sorted(expected - satisfied)
+    last = runs[-1]
+    overall = "ok" if not incomplete else "incomplete"
+    return {
+        "runs": len(runs),
+        "total_tokens": total_tokens,
+        "total_tool_uses": total_tool_uses,
+        "total_duration_seconds": round(total_duration, 2),
+        "expected_unique_ids": len(expected),
+        "satisfied_unique_ids": len(satisfied),
+        "incomplete_ids": incomplete,
+        "last_run_status": last.get("status"),
+        "overall_status": overall,
+        "had_retries": any(
+            r.get("retry_of_run_index") is not None for r in runs
+        ),
+    }
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="agent_run_log",
+        description="Log Task-agent runs to audit-meta.json.",
+    )
+    sub = parser.add_subparsers(dest="cmd", required=True)
+
+    p_log = sub.add_parser("log", help="Append a run entry")
+    p_log.add_argument(
+        "--meta-path",
+        required=True,
+        help="Path to audit-meta.json (created if missing)",
+    )
+    p_log.add_argument("--tool-uses", type=int, required=True)
+    p_log.add_argument("--tokens", type=int, required=True)
+    p_log.add_argument("--duration", type=float, required=True)
+    p_log.add_argument(
+        "--expected",
+        required=True,
+        help="Comma-separated expected check IDs",
+    )
+    p_log.add_argument(
+        "--raw-dir",
+        required=True,
+        help="Directory containing per-check raw output files",
+    )
+    p_log.add_argument("--min-bytes", type=int, default=1)
+    p_log.add_argument(
+        "--retry-of",
+        type=int,
+        default=None,
+        help="If this run is a retry, the run_index it retries",
+    )
+
+    p_sum = sub.add_parser("summary", help="Print summary of recorded runs")
+    p_sum.add_argument("--meta-path", required=True)
+
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    force_utf8_stdio()
+    args = _build_parser().parse_args(argv)
+    meta_path = Path(args.meta_path)
+
+    if args.cmd == "log":
+        meta = load_meta(meta_path)
+        ids = [s.strip() for s in args.expected.split(",") if s.strip()]
+        entry = append_run(
+            meta,
+            tool_uses=args.tool_uses,
+            tokens=args.tokens,
+            duration_seconds=args.duration,
+            expected_ids=ids,
+            raw_dir=Path(args.raw_dir),
+            min_bytes=args.min_bytes,
+            retry_of_run_index=args.retry_of,
+        )
+        save_meta(meta_path, meta)
+        print(json.dumps(entry, indent=2, ensure_ascii=False))
+        # Exit non-zero on incomplete/empty so the caller can branch.
+        return 0 if entry["status"] == "ok" else 1
+
+    if args.cmd == "summary":
+        if not meta_path.exists():
+            print(f"Error: {meta_path} not found", file=sys.stderr)
+            return 2
+        meta = load_meta(meta_path)
+        summary = summarise(meta)
+        print(json.dumps(summary, indent=2, ensure_ascii=False))
+        return 0 if summary.get("overall_status") in ("ok", "no-runs") else 1
+
+    return 2
+
+
+if __name__ == "__main__":  # pragma: no cover
+    sys.exit(main())

--- a/tools/verify_raw_outputs.py
+++ b/tools/verify_raw_outputs.py
@@ -1,0 +1,193 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Verify raw/ output completeness after Task-agent execution.
+
+Solves the silent-failure problem from issue #12: in the first real audit,
+a Task-agent returned `Done (68 tool uses · 0 tokens · 2m 20s)` — meaning
+the agent returned no actual output — and the skill didn't notice. With
+this verifier, Step 4 has a concrete gate after every Task-agent run.
+
+Outcomes (exit code):
+  0 — all expected IDs have non-empty output files
+  1 — some IDs are missing or have empty output files
+  2 — usage error (bad arguments, missing dir)
+
+Usage:
+    python tools/verify_raw_outputs.py raw/ \
+        --expected-ids ARCH-001,ARCH-002,SEC-021
+
+    python tools/verify_raw_outputs.py raw/ \
+        --expected-ids-file expected.txt
+
+    python tools/verify_raw_outputs.py raw/ \
+        --expected-ids-file expected.txt \
+        --min-bytes 10  # threshold for "non-empty"
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+# Bootstrap so tools.* imports work when invoked as a script.
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from tools.path_utils import force_utf8_stdio  # noqa: E402
+
+
+DEFAULT_MIN_BYTES = 1
+DEFAULT_FILE_SUFFIX = ".txt"
+
+
+def verify_raw_outputs(
+    raw_dir: Path,
+    expected_ids: list[str],
+    min_bytes: int = DEFAULT_MIN_BYTES,
+    suffix: str = DEFAULT_FILE_SUFFIX,
+) -> dict[str, Any]:
+    """Compare expected check-IDs against persisted raw/ output files.
+
+    A check-ID is considered "satisfied" iff the file `<raw_dir>/<id><suffix>`
+    exists AND is at least `min_bytes` bytes long. The byte-size threshold
+    catches the original silent-failure mode where Task-agent returns 0
+    tokens and writes empty placeholder files.
+
+    Returns a structured report:
+        {
+          "expected": [...],
+          "satisfied": [...],
+          "missing": [...],
+          "empty": [...],   # exists but below min_bytes
+          "consistent": bool,
+          "incomplete_ids": [...],  # missing + empty, ready to retry
+        }
+    """
+    if not raw_dir.exists():
+        return {
+            "expected": list(expected_ids),
+            "satisfied": [],
+            "missing": list(expected_ids),
+            "empty": [],
+            "consistent": False,
+            "incomplete_ids": list(expected_ids),
+            "error": f"raw_dir {raw_dir} does not exist",
+        }
+
+    satisfied: list[str] = []
+    missing: list[str] = []
+    empty: list[str] = []
+    for cid in expected_ids:
+        path = raw_dir / f"{cid}{suffix}"
+        if not path.exists():
+            missing.append(cid)
+            continue
+        try:
+            size = path.stat().st_size
+        except OSError:
+            missing.append(cid)
+            continue
+        if size < min_bytes:
+            empty.append(cid)
+            continue
+        satisfied.append(cid)
+
+    incomplete = missing + empty
+    return {
+        "expected": list(expected_ids),
+        "satisfied": satisfied,
+        "missing": missing,
+        "empty": empty,
+        "consistent": not incomplete,
+        "incomplete_ids": incomplete,
+    }
+
+
+def _load_expected_ids(path: Path) -> list[str]:
+    """One ID per line; skip blanks and comments."""
+    ids: list[str] = []
+    for line in path.read_text(encoding="utf-8").splitlines():
+        s = line.strip()
+        if not s or s.startswith("#"):
+            continue
+        ids.append(s)
+    return ids
+
+
+def main(argv: list[str] | None = None) -> int:
+    force_utf8_stdio()
+    parser = argparse.ArgumentParser(
+        prog="verify_raw_outputs",
+        description=(
+            "Verify that Task-agent runs persisted output for every "
+            "expected check ID. Exit 0=ok, 1=incomplete, 2=usage error."
+        ),
+    )
+    parser.add_argument(
+        "raw_dir",
+        help="Directory of per-check raw output files",
+    )
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument(
+        "--expected-ids",
+        help="Comma-separated list of expected check IDs",
+    )
+    group.add_argument(
+        "--expected-ids-file",
+        help="Path to a file with one expected check ID per line",
+    )
+    parser.add_argument(
+        "--suffix",
+        default=DEFAULT_FILE_SUFFIX,
+        help=f"File suffix (default: {DEFAULT_FILE_SUFFIX!r})",
+    )
+    parser.add_argument(
+        "--min-bytes",
+        type=int,
+        default=DEFAULT_MIN_BYTES,
+        help=(
+            "Minimum file size to count as non-empty. Catches the "
+            "0-token-Task-agent failure mode (default: 1)"
+        ),
+    )
+    parser.add_argument(
+        "--out",
+        default=None,
+        help="Write JSON report to this path; otherwise print to stdout",
+    )
+    args = parser.parse_args(argv)
+
+    if args.expected_ids:
+        ids = [s.strip() for s in args.expected_ids.split(",") if s.strip()]
+    else:
+        ids_file = Path(args.expected_ids_file)
+        if not ids_file.exists():
+            print(f"Error: {ids_file} not found", file=sys.stderr)
+            return 2
+        ids = _load_expected_ids(ids_file)
+
+    if not ids:
+        print("Error: no expected IDs given", file=sys.stderr)
+        return 2
+
+    raw_dir = Path(args.raw_dir)
+    if not raw_dir.exists():
+        # We still produce a structured report; CLI also exits non-zero.
+        report = verify_raw_outputs(raw_dir, ids, args.min_bytes, args.suffix)
+    else:
+        report = verify_raw_outputs(raw_dir, ids, args.min_bytes, args.suffix)
+
+    text = json.dumps(report, indent=2, ensure_ascii=False)
+    if args.out:
+        Path(args.out).write_text(text + "\n", encoding="utf-8")
+    else:
+        print(text)
+
+    return 0 if report["consistent"] else 1
+
+
+if __name__ == "__main__":  # pragma: no cover
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Closes #12.

In the first real audit a Task-agent returned `Done (68 tool uses · 0 tokens · 2m 20s)` — a complete silent failure. The skill didn't notice; Claude manually compensated. In an unattended audit (CI-driven), this would mean silent data loss.

This PR adds two helper scripts that close the gap and a verbal contract in SKILL.md Step 4.5.

## What changed

### `tools/verify_raw_outputs.py` — post-Task-agent verification gate
- Compares expected check-IDs against `raw/<id>.txt` files on disk.
- `--min-bytes` threshold catches empty-placeholder files (the silent-failure mode from #12).
- Exit `0` (consistent), `1` (incomplete — missing or empty files), `2` (usage error).
- Returns structured JSON listing `satisfied`, `missing`, `empty`, `incomplete_ids`.

### `tools/agent_run_log.py` — Task-agent run audit trail
- Appends one entry per agent run to `audit-meta.json` with tool-uses, tokens, duration, expected/satisfied/incomplete IDs.
- **Three-state classification:**
  - `ok` — tokens > 0 AND no incomplete IDs
  - `incomplete` — tokens > 0 BUT some IDs missing/empty
  - `empty` — tokens == 0 (always wins; bypassed even if files happen to exist beforehand, since 0 tokens means the agent didn't do work)
- `summary` subcommand aggregates across all runs (e.g. for retry counting).
- Honours the `--retry-of <run_index>` link so Step 4 retries form a chain.

### `SKILL.md` Step 4.5 — mandatory validation gate
- Documents the post-agent verify + log workflow.
- **Retry policy:** max 2 retries on `incomplete`/`empty`, only for the missing IDs. Hard abort after that.
- Also updates the helper-script table in Step 0.3.

### `audit-mcp.md` slash command Step 4
- Emits `verify_raw_outputs.py` and `agent_run_log.py` calls after each Task-agent batch.
- `summary` is required at end-of-Step-4; `overall_status == "ok"` is the gate to enter Step 5.

## Test plan

- [x] `python -m pytest tests/` — 176 passed (139 → 176, +37 cases)
- [x] `tests/test_verify_raw_outputs.py` — 14 cases including the 0-byte file detection
- [x] `tests/test_agent_run_log.py` — 23 cases including a regression test that replays the exact 0-tokens scenario from the original audit
- [x] CLIs work standalone (verified via `--help` smoke)
- [ ] CI green on Ubuntu + Windows runners

## Out of scope (separate PRs)

- #13 — `write_access` vs. `write_capable` schema migration
- #14 — Profile placeholder detection
- #15 — Audit run-id with timezone
- #16 — Migrate the 9 broken `applies_when` expressions


---
_Generated by [Claude Code](https://claude.ai/code/session_01PgYtwRK14HmFwES2PusuHH)_