### PR TITLE
Migrate write_access → write_capable schema (closes #13)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ Versionierung: [Semantic Versioning](https://semver.org/lang/de/).
 
 ## [Unreleased]
 
+### Geändert — Schema-Migration `write_access` → `write_capable` (Issue #13)
+
+Der Skill hatte zwei parallele Profil-Felder für dieselbe Frage "schreibt der Server?": `write_access: "write-capable"` (Enum-String) und `write_capable: bool`. Damit hing die Applicability eines Checks davon ab, welche Variante das Profil zufällig setzte. Issue #6 (canonical evaluator) hat das offengelegt; jetzt aufgeräumt.
+
+**Entscheidung:** `write_capable: bool` ist das kanonische Feld (kürzer, eindeutig boolesch, konsistent mit `uses_sampling: bool`, `tools_make_external_requests: bool`). `write_access` ist deprecated und wird vom Evaluator als `UnknownFieldError` geflaggt — keine stille Backwards-Compatibility, weil das exakt die "loud failure"-Philosophie aus Issue #6 verletzt hätte.
+
+- **`checks/HITL-005.md`** migriert: `write_access == "write-capable"` → `write_capable == true`
+- **`SKILL.md`** Profil-Beispiel und Schema-Hinweis aktualisiert; klargestellt, dass das Notion-Tracker-Select `Schreibzugriff` durch `audit-notion-sync.py` automatisch zu `write_capable: bool` gemappt wird (Notion-UX bleibt unverändert)
+- **`tests/test_applicability.py`** — neue Klasse `TestWriteCapableSchemaMigration` mit 5 Cases: kein Check nutzt `write_access` mehr, HITL-005 nutzt das neue Feld, korrekte Applicability bei `write_capable=true/false`, Legacy-Profile werden laut abgelehnt
+- Test-Total: 176 → 181
+
 ### Hinzugefügt — Task-Agent-Validation-Gate (Issue #12)
 
 Im ersten realen Audit hat ein Task-Agent mit `Done (68 tool uses · 0 tokens · 2m 20s)` zurückgegeben — vollständiger stiller Fehlschlag. Der Skill hat das nicht erkannt, Claude hat manuell weitergemacht und das Problem ad hoc kompensiert. Bei einem unbeaufsichtigten Audit wäre das stiller Datenverlust gewesen.

--- a/SKILL.md
+++ b/SKILL.md
@@ -111,12 +111,14 @@ profile:
   transport: dual
   auth_model: none
   data_class: Public Open Data
-  write_access: read-only
+  write_capable: false       # bool — kanonisches Feld (siehe Migration unten)
   deployment: [local-stdio, Railway]
   prio: 14  # aus Tracker-Formel
 ```
 
 Dieses Profil ist die **einzige Wahrheit** für `applies_when`-Auswertung in Schritt 3.
+
+**Schema-Hinweis (seit Issue #13):** Das kanonische Profil-Feld ist `write_capable: bool`. Das frühere `write_access: "read-only" | "write-capable"` (Enum-String) wurde abgelöst. Der Notion-Tracker behält das `Schreibzugriff`-Select-Feld zur besseren Lesbarkeit; `audit-notion-sync.py` mappt es beim `pull` automatisch auf `write_capable: bool`. Profile mit Legacy-Feld `write_access` führen beim Evaluator zu `UnknownFieldError` — das ist beabsichtigt (siehe `docs/applies-when-dsl.md` "loud failure"-Prinzip).
 
 ---
 

--- a/checks/HITL-005.md
+++ b/checks/HITL-005.md
@@ -3,7 +3,7 @@ id: HITL-005
 title: "Destructive Operation Confirmation"
 category: HITL
 severity: critical
-applies_when: 'write_access == "write-capable"'
+applies_when: 'write_capable == true'
 pdf_ref: "Sec 7.2"
 evidence_required: 3
 ---

--- a/tests/test_applicability.py
+++ b/tests/test_applicability.py
@@ -366,6 +366,68 @@ class TestRealCatalog:
         assert results["SEC-001"]["applicable"] is True
 
 
+class TestWriteCapableSchemaMigration:
+    """Regression for issue #13: the catalog must use `write_capable: bool`
+    everywhere; the legacy `write_access` enum is dropped.
+    """
+
+    def test_no_check_uses_legacy_write_access_field(self):
+        from tools.parse_catalog import parse_catalog
+        catalog = parse_catalog(CHECKS_DIR)
+        offenders = [
+            cid for cid, fm in catalog.items()
+            if "write_access" in fm.get("applies_when", "")
+        ]
+        assert offenders == [], (
+            f"These checks still reference the deprecated write_access "
+            f"field: {offenders}. Migrate to write_capable == true/false."
+        )
+
+    def test_hitl_005_uses_canonical_field(self):
+        from tools.eval_applicability import parse_check_frontmatter
+        fm = parse_check_frontmatter(CHECKS_DIR / "HITL-005.md")
+        assert fm["applies_when"] == "write_capable == true"
+
+    def test_write_capable_false_skips_hitl_005(self, srgssr_profile):
+        # srgssr has write_capable=False → HITL-005 must NOT apply.
+        results = evaluate_catalog(srgssr_profile, CHECKS_DIR)
+        assert results["HITL-005"]["applicable"] is False
+
+    def test_write_capable_true_activates_hitl_005(self, cloud_oauth_profile):
+        # cloud_oauth has write_capable=True → HITL-005 must apply.
+        results = evaluate_catalog(cloud_oauth_profile, CHECKS_DIR)
+        assert results["HITL-005"]["applicable"] is True
+
+    def test_legacy_profile_with_only_write_access_fails_loudly(self):
+        # If a user provides a legacy profile (write_access only, no
+        # write_capable), every write-related check must error rather
+        # than silently default to False.
+        legacy_profile = {
+            "transport": "stdio-only",
+            "auth_model": "none",
+            "data_class": "Public Open Data",
+            "write_access": "read-only",  # legacy
+            # NOTE: no write_capable
+            "deployment": ["local-stdio"],
+            "uses_sampling": False,
+            "uses_sequential_thinking": False,
+            "tools_include_filesystem": False,
+            "tools_make_external_requests": False,
+            "stadt_zuerich_context": False,
+            "schulamt_context": False,
+            "volksschule_context": False,
+            "enterprise_context": False,
+            "sdk_language": "Python",
+            "data_source": {"is_swiss_open_data": False},
+        }
+        results = evaluate_catalog(legacy_profile, CHECKS_DIR)
+        # HITL-005 evaluates `write_capable == true` against a profile
+        # that only has `write_access` → UnknownFieldError surfaces as
+        # `unknown-field` reason in the catalog runner.
+        assert results["HITL-005"]["applicable"] is False
+        assert results["HITL-005"]["reason"].startswith("unknown-field")
+
+
 class TestFrontmatterParser:
     def test_parse_arch_001(self):
         fm = parse_check_frontmatter(CHECKS_DIR / "ARCH-001.md")


### PR DESCRIPTION
## Summary

Closes #13.

Two parallel profile fields covered the same question "does the server write?":

```
checks/HITL-005.md:  applies_when: 'write_access == "write-capable"'
checks/ARCH-010.md:  applies_when: 'write_capable == true'
```

Applicability depended on whichever variant the profile happened to set. Resolved by making `write_capable: bool` the single canonical field.

## Decision rationale

| | `write_access` (string) | `write_capable` (bool) |
|---|---|---|
| Verbosity | `write_access: "write-capable"` | `write_capable: true` |
| Type clarity | enum-as-string | unambiguous bool |
| Consistency with siblings | unique | matches `uses_sampling`, `tools_make_external_requests`, `tools_include_filesystem` |

`write_capable: bool` wins on all three. **No backwards-compatibility shim** — a legacy profile with only `write_access` produces `UnknownFieldError`. Adding silent fallback would violate the loud-failure principle from #6 (the whole point of the canonical evaluator).

## What changed

- **`checks/HITL-005.md`** — `applies_when` migrated to `write_capable == true`
- **`SKILL.md`** — profile YAML example updated; new schema note clarifies that the Notion `Schreibzugriff` Select-Property stays as-is (better UX than a checkbox), and `audit-notion-sync.py` already maps it to `write_capable: bool` on pull
- **`tests/test_applicability.py::TestWriteCapableSchemaMigration`** — 5 new cases:
  1. `test_no_check_uses_legacy_write_access_field` — sweep over all 68 checks, asserts none reference `write_access` anymore (regression catch for future check additions)
  2. `test_hitl_005_uses_canonical_field`
  3. `test_write_capable_false_skips_hitl_005`
  4. `test_write_capable_true_activates_hitl_005`
  5. `test_legacy_profile_with_only_write_access_fails_loudly` — confirms the loud-failure design

## Test plan

- [x] `python -m pytest tests/` — 181 passed (176 → 181, +5 cases)
- [x] `python tools/eval_applicability.py expr 'write_capable == true' portfolio.example.yaml` — works (returns `false` for the example portfolio's first server)
- [x] No checks reference `write_access` anymore (sweep test)
- [ ] CI green on Ubuntu + Windows runners

## Out of scope (separate PRs)

- #14 — Profile placeholder detection
- #15 — Audit run-id with timezone
- #16 — Migrate the 9 broken `applies_when` expressions (deployment list-vs-string)


---
_Generated by [Claude Code](https://claude.ai/code/session_01PgYtwRK14HmFwES2PusuHH)_