### PR TITLE
Replace 9 broken deployment-vs-string checks with is_cloud_deployed flag (closes #16)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ Versionierung: [Semantic Versioning](https://semver.org/lang/de/).
 
 ## [Unreleased]
 
+### Geändert — `is_cloud_deployed`-Flag ersetzt 9 broken `deployment`-Checks (Issue #16)
+
+Der canonical evaluator (Issue #6) hatte 9 Checks identifiziert, die das Listen-Feld `deployment` mit einem String-Literal verglichen — `deployment != "local-stdio"`. Im alten ad-hoc-Evaluator (Python `eval`) lieferte das immer `True` (`["x"] != "x"` ist in Python immer wahr), wodurch die Checks fälschlich für jeden Server als anwendbar galten. Jetzt strukturell behoben.
+
+**Entscheidung (Option C aus Issue #16):** Neues Profil-Feld `is_cloud_deployed: bool`, abgeleitet aus dem `deployment`-Listen-Feld (`true` iff mindestens ein Eintrag ungleich `local-stdio`). Vorteile: explizite Intention, kein DSL-Change, gleichlautend zu `write_capable`/`uses_sampling`.
+
+- **9 Check-Files migriert:** `OBS-005`, `OBS-006`, `SCALE-003`, `SCALE-004`, `SCALE-006`, `SEC-014`, `SEC-015`, `SEC-021`, `SEC-022` — `applies_when` von `deployment != "local-stdio"` auf `is_cloud_deployed == true` umgestellt
+- **`audit-notion-sync.py build_profile`** leitet `is_cloud_deployed` automatisch aus `deployment` ab — Notion-Tracker bleibt unverändert (single source of truth: `Deployment`-Multi-Select)
+- **`portfolio.example.yaml` + `SKILL.md`** dokumentieren das neue Feld
+- **`docs/applies-when-dsl.md`** Anti-Pattern-Sektion aktualisiert: list-vs-string-Anti-Pattern explizit auf `is_cloud_deployed`-Lösung verwiesen
+- **Tests:** `KNOWN_BUGGY_DEPLOYMENT_COMPARISON`-Set entfernt (nun leer); neue `TestIsCloudDeployedFlag`-Klasse mit 5 Cases für die Flag-Semantik; `test_no_check_compares_deployment_list_to_string_literal` als Regression-Sweep über alle 68 Checks; neuer `tests/test_notion_sync.py` (7 Cases) verifiziert die Notion-Sync-Derivation
+- Test-Total: 181 → 195
+
 ### Geändert — Schema-Migration `write_access` → `write_capable` (Issue #13)
 
 Der Skill hatte zwei parallele Profil-Felder für dieselbe Frage "schreibt der Server?": `write_access: "write-capable"` (Enum-String) und `write_capable: bool`. Damit hing die Applicability eines Checks davon ab, welche Variante das Profil zufällig setzte. Issue #6 (canonical evaluator) hat das offengelegt; jetzt aufgeräumt.

--- a/SKILL.md
+++ b/SKILL.md
@@ -111,8 +111,9 @@ profile:
   transport: dual
   auth_model: none
   data_class: Public Open Data
-  write_capable: false       # bool — kanonisches Feld (siehe Migration unten)
+  write_capable: false              # bool — kanonisches Feld (siehe Migration unten)
   deployment: [local-stdio, Railway]
+  is_cloud_deployed: true           # derived: true iff deployment hat irgendwas ausser local-stdio (siehe Issue #16)
   prio: 14  # aus Tracker-Formel
 ```
 

--- a/audit-notion-sync.py
+++ b/audit-notion-sync.py
@@ -167,6 +167,10 @@ def build_profile(props: dict[str, Any]) -> dict[str, Any]:
         "data_class": data_class,
         "write_capable": write_access == "write-capable",
         "deployment": deployment,
+        # Derived flag (issue #16): true iff at least one deployment target
+        # is something other than `local-stdio`. Replaces the broken
+        # `deployment != "local-stdio"` list-vs-string comparison in 9 checks.
+        "is_cloud_deployed": any(d != "local-stdio" for d in deployment),
     }
     profile.update(DEFAULT_TECH_FLAGS)
     for option_name, flag_name in ORG_CONTEXT_OPTIONS.items():

--- a/checks/OBS-005.md
+++ b/checks/OBS-005.md
@@ -3,7 +3,7 @@ id: OBS-005
 title: "SIEM-Integration für Audit-Logs (Datadog/Splunk)"
 category: OBS
 severity: medium
-applies_when: 'deployment != "local-stdio" and data_class != "Public Open Data"'
+applies_when: 'is_cloud_deployed == true and data_class != "Public Open Data"'
 pdf_ref: "Sec 6.3"
 evidence_required: 2
 ---

--- a/checks/OBS-006.md
+++ b/checks/OBS-006.md
@@ -3,7 +3,7 @@ id: OBS-006
 title: "OpenTelemetry Distributed Tracing pro Tool-Call"
 category: OBS
 severity: medium
-applies_when: 'deployment != "local-stdio"'
+applies_when: 'is_cloud_deployed == true'
 pdf_ref: "Anhang B10"
 evidence_required: 3
 ---
@@ -29,7 +29,7 @@ Dieser Check ist `medium`, weil ohne Tracing zwar der Server funktioniert, aber 
 
 OpenTelemetry ist Industriestandard, vendor-neutral, mit Anbindern an alle gängigen Observability-Tools (Datadog, Splunk, Grafana Tempo, Honeycomb, Jaeger).
 
-Im lokalen stdio-Setup ist Tracing weniger wichtig (Single-User-Latenzen sind meist nicht das Problem), daher `applies_when: deployment != "local-stdio"`.
+Im lokalen stdio-Setup ist Tracing weniger wichtig (Single-User-Latenzen sind meist nicht das Problem), daher `applies_when: is_cloud_deployed == true`.
 
 ## Verification
 

--- a/checks/SCALE-003.md
+++ b/checks/SCALE-003.md
@@ -3,7 +3,7 @@ id: SCALE-003
 title: "Mcp-Session-Id Routing via Edge-LB (HAProxy Stick-Tables)"
 category: SCALE
 severity: high
-applies_when: '(transport == "HTTP/SSE" or transport == "dual") and deployment != "local-stdio"'
+applies_when: '(transport == "HTTP/SSE" or transport == "dual") and is_cloud_deployed == true'
 pdf_ref: "Sec 5.2"
 evidence_required: 2
 ---

--- a/checks/SCALE-004.md
+++ b/checks/SCALE-004.md
@@ -3,7 +3,7 @@ id: SCALE-004
 title: "Containerization mit Multi-Stage-Builds"
 category: SCALE
 severity: medium
-applies_when: 'deployment != "local-stdio"'
+applies_when: 'is_cloud_deployed == true'
 pdf_ref: "Sec 5.3"
 evidence_required: 2
 ---

--- a/checks/SCALE-006.md
+++ b/checks/SCALE-006.md
@@ -3,7 +3,7 @@ id: SCALE-006
 title: "Resource-Limits per Container (Memory, CPU, FDs)"
 category: SCALE
 severity: medium
-applies_when: 'deployment != "local-stdio"'
+applies_when: 'is_cloud_deployed == true'
 pdf_ref: "Sec 5.3"
 evidence_required: 2
 ---

--- a/checks/SEC-014.md
+++ b/checks/SEC-014.md
@@ -3,7 +3,7 @@ id: SEC-014
 title: "Tool-Allow-Listing via MCP-Gateway-Pattern"
 category: SEC
 severity: medium
-applies_when: 'enterprise_context == true or stadt_zuerich_context == true or deployment != "local-stdio"'
+applies_when: 'enterprise_context == true or stadt_zuerich_context == true or is_cloud_deployed == true'
 pdf_ref: "Sec 5.3"
 evidence_required: 2
 ---

--- a/checks/SEC-015.md
+++ b/checks/SEC-015.md
@@ -3,7 +3,7 @@ id: SEC-015
 title: "Pre-Flight Tool-Poisoning Detection"
 category: SEC
 severity: medium
-applies_when: 'enterprise_context == true or stadt_zuerich_context == true or deployment != "local-stdio"'
+applies_when: 'enterprise_context == true or stadt_zuerich_context == true or is_cloud_deployed == true'
 pdf_ref: "Sec 5.3"
 evidence_required: 2
 ---

--- a/checks/SEC-021.md
+++ b/checks/SEC-021.md
@@ -3,7 +3,7 @@ id: SEC-021
 title: "Egress-Allow-List: Code-Layer und Network-Layer"
 category: SEC
 severity: high
-applies_when: 'tools_make_external_requests == true or deployment != "local-stdio"'
+applies_when: 'tools_make_external_requests == true or is_cloud_deployed == true'
 pdf_ref: "Anhang B5 + B12"
 evidence_required: 4
 ---

--- a/checks/SEC-022.md
+++ b/checks/SEC-022.md
@@ -3,7 +3,7 @@ id: SEC-022
 title: "Tool-Hash-Pinning + Namespace-Präfix gegen Rug Pull"
 category: SEC
 severity: high
-applies_when: 'enterprise_context == true or stadt_zuerich_context == true or deployment != "local-stdio"'
+applies_when: 'enterprise_context == true or stadt_zuerich_context == true or is_cloud_deployed == true'
 pdf_ref: "Anhang B4"
 evidence_required: 3
 ---

--- a/docs/applies-when-dsl.md
+++ b/docs/applies-when-dsl.md
@@ -99,13 +99,21 @@ If any segment is missing, evaluation raises `UnknownFieldError`. Silent fallbac
 applies_when: 'deployment != "local-stdio"'
 ```
 
-The legacy ad-hoc evaluator silently treated this as `True` for any non-empty list, leading to false-positive applicability. The canonical evaluator raises `TypeMismatchError`. See issue #16.
+The legacy ad-hoc evaluator silently treated this as `True` for any non-empty list, leading to false-positive applicability. The canonical evaluator raises `TypeMismatchError`. Resolved in issue #16: a derived boolean `is_cloud_deployed` was added to the profile schema, and the 9 affected checks were migrated.
 
-**Fix patterns:**
+**Canonical fix (since #16):**
 
 ```yaml
-# Positive disjunction over cloud targets
-applies_when: 'deployment.includes("Railway") or deployment.includes("Render") or deployment.includes("Kubernetes")'
+applies_when: 'is_cloud_deployed == true'
+```
+
+Semantic: `is_cloud_deployed` is `true` iff the `deployment` list contains at least one entry that is not `local-stdio`. The flag is derived automatically by `audit-notion-sync.py` from the Notion `Deployment` multi-select; portfolio.yaml authors must set it explicitly.
+
+**Alternative for finer-grained checks:**
+
+```yaml
+# Multi-select membership without the boolean shortcut
+applies_when: 'deployment.includes("Railway")'
 ```
 
 ### Capitalised booleans

--- a/portfolio.example.yaml
+++ b/portfolio.example.yaml
@@ -22,6 +22,7 @@ servers:
       data_class: Public Open Data                 # Public Open Data | Verwaltungsdaten | PII
       write_capable: false
       deployment: [local-stdio, Railway]           # Liste: local-stdio | Railway | Render | Kubernetes | Docker
+      is_cloud_deployed: true                      # derived: true iff deployment has anything besides local-stdio
       uses_sampling: false
       uses_sequential_thinking: false
       tools_include_filesystem: false
@@ -41,6 +42,7 @@ servers:
       data_class: Verwaltungsdaten
       write_capable: false
       deployment: [local-stdio]
+      is_cloud_deployed: false
       uses_sampling: false
       uses_sequential_thinking: false
       tools_include_filesystem: false

--- a/tests/test_applicability.py
+++ b/tests/test_applicability.py
@@ -38,6 +38,7 @@ def srgssr_profile() -> dict:
         "write_capable": False,
         "write_access": "read-only",
         "deployment": ["local-stdio"],
+        "is_cloud_deployed": False,
         "uses_sampling": False,
         "uses_sequential_thinking": False,
         "tools_include_filesystem": False,
@@ -61,6 +62,7 @@ def zh_education_profile() -> dict:
         "write_capable": False,
         "write_access": "read-only",
         "deployment": ["local-stdio"],
+        "is_cloud_deployed": False,
         "uses_sampling": False,
         "uses_sequential_thinking": False,
         "tools_include_filesystem": False,
@@ -84,6 +86,7 @@ def cloud_oauth_profile() -> dict:
         "write_capable": True,
         "write_access": "write-capable",
         "deployment": ["Railway"],
+        "is_cloud_deployed": True,
         "uses_sampling": True,
         "uses_sequential_thinking": True,
         "tools_include_filesystem": True,
@@ -307,12 +310,11 @@ class TestRealCatalog:
             f"({applicable})"
         )
 
-    # Checks with known broken applies_when (compare list field `deployment`
-    # to string literal). The canonical evaluator surfaces this as a
-    # type-mismatch; the legacy ad-hoc evaluator silently coerced these
-    # to True (Python `[...] != "x"` is always True). Tracked in a
-    # follow-up issue for catalog rewrite.
-    KNOWN_BUGGY_DEPLOYMENT_COMPARISON = {
+    # The 9 checks that previously had `deployment != "local-stdio"` were
+    # migrated to `is_cloud_deployed == true` in issue #16. The catalog
+    # must now be type-clean — every check evaluates without a
+    # type-mismatch error against any well-formed profile.
+    PREVIOUSLY_BUGGY_CHECKS = {
         "OBS-005",
         "OBS-006",
         "SCALE-003",
@@ -329,26 +331,41 @@ class TestRealCatalog:
         unexpected = {
             cid: r["reason"]
             for cid, r in results.items()
-            if not r["applicable"]
-            and r["reason"] != "no-match"
-            and cid not in self.KNOWN_BUGGY_DEPLOYMENT_COMPARISON
+            if not r["applicable"] and r["reason"] != "no-match"
         }
         assert unexpected == {}, (
             "Unexpected evaluator errors against srgssr profile (catalog drift?): "
             f"{unexpected}"
         )
 
-    def test_known_buggy_checks_still_flagged(self, srgssr_profile):
-        """Regression: ensure the canonical evaluator keeps flagging the
-        list-vs-string comparison bug. When the catalog is fixed, this
-        test plus the KNOWN_BUGGY set must be updated together.
+    def test_no_check_compares_deployment_list_to_string_literal(self):
+        """Regression for issue #16: no check may compare the `deployment`
+        list field directly to a string literal again. Migrated to
+        `is_cloud_deployed == true` instead.
         """
+        from tools.parse_catalog import parse_catalog
+        catalog = parse_catalog(CHECKS_DIR)
+        offenders = [
+            cid for cid, fm in catalog.items()
+            if 'deployment !=' in fm.get("applies_when", "")
+            or 'deployment ==' in fm.get("applies_when", "")
+        ]
+        assert offenders == [], (
+            f"These checks compare `deployment` to a string literal "
+            f"(issue #16): {offenders}. Use `is_cloud_deployed == true` "
+            f"or `deployment.includes(\"...\")` instead."
+        )
+
+    def test_previously_buggy_checks_now_evaluate_clean(self, srgssr_profile):
+        """The 9 checks migrated under #16 must produce no type-mismatch."""
         results = evaluate_catalog(srgssr_profile, CHECKS_DIR)
-        flagged = {
-            cid for cid, r in results.items()
-            if r["reason"].startswith("type-mismatch")
-        }
-        assert flagged == self.KNOWN_BUGGY_DEPLOYMENT_COMPARISON
+        for cid in self.PREVIOUSLY_BUGGY_CHECKS:
+            r = results.get(cid)
+            assert r is not None, f"{cid}: missing from catalog"
+            assert not r["reason"].startswith("type-mismatch"), (
+                f"{cid}: still produces a type-mismatch — migration "
+                f"incomplete? reason={r['reason']!r}"
+            )
 
     def test_arch_001_is_universal(self, srgssr_profile, cloud_oauth_profile):
         # ARCH-001 is `applies_when: 'always'` — must be applicable everywhere.
@@ -364,6 +381,81 @@ class TestRealCatalog:
     def test_oauth_proxy_check_active_for_oauth(self, cloud_oauth_profile):
         results = evaluate_catalog(cloud_oauth_profile, CHECKS_DIR)
         assert results["SEC-001"]["applicable"] is True
+
+
+class TestIsCloudDeployedFlag:
+    """Issue #16: the `is_cloud_deployed` flag replaces the broken
+    list-vs-string comparison `deployment != "local-stdio"`.
+    Semantic: `true` iff at least one deployment target is not `local-stdio`.
+    """
+
+    def test_local_stdio_only_skips_cloud_checks(self, srgssr_profile):
+        # srgssr has deployment=[local-stdio], is_cloud_deployed=False
+        results = evaluate_catalog(srgssr_profile, CHECKS_DIR)
+        # OBS-006 is `is_cloud_deployed == true` — must NOT apply
+        assert results["OBS-006"]["applicable"] is False
+        assert results["SCALE-004"]["applicable"] is False
+        assert results["SCALE-006"]["applicable"] is False
+
+    def test_cloud_deployment_activates_cloud_checks(self, cloud_oauth_profile):
+        # cloud_oauth has deployment=[Railway], is_cloud_deployed=True
+        results = evaluate_catalog(cloud_oauth_profile, CHECKS_DIR)
+        assert results["OBS-006"]["applicable"] is True
+        assert results["SCALE-004"]["applicable"] is True
+        assert results["SCALE-006"]["applicable"] is True
+
+    def test_sec_021_or_with_external_requests(self, srgssr_profile):
+        # srgssr has tools_make_external_requests=True so SEC-021 must
+        # apply via the OR-arm even though is_cloud_deployed=False.
+        results = evaluate_catalog(srgssr_profile, CHECKS_DIR)
+        assert results["SEC-021"]["applicable"] is True
+
+    def test_sec_021_skipped_for_pure_local_no_external(self):
+        # Local-stdio AND no external requests → SEC-021 must NOT apply
+        profile = {
+            "transport": "stdio-only",
+            "auth_model": "none",
+            "data_class": "Public Open Data",
+            "write_capable": False,
+            "deployment": ["local-stdio"],
+            "is_cloud_deployed": False,
+            "uses_sampling": False,
+            "uses_sequential_thinking": False,
+            "tools_include_filesystem": False,
+            "tools_make_external_requests": False,
+            "stadt_zuerich_context": False,
+            "schulamt_context": False,
+            "volksschule_context": False,
+            "enterprise_context": False,
+            "sdk_language": "Python",
+            "data_source": {"is_swiss_open_data": True},
+        }
+        results = evaluate_catalog(profile, CHECKS_DIR)
+        assert results["SEC-021"]["applicable"] is False
+
+    def test_dual_deployment_with_local_and_cloud_is_cloud(self):
+        # deployment=[local-stdio, Railway] → is_cloud_deployed=True
+        # The example portfolio's first server is exactly this case.
+        profile = {
+            "transport": "dual",
+            "auth_model": "none",
+            "data_class": "Public Open Data",
+            "write_capable": False,
+            "deployment": ["local-stdio", "Railway"],
+            "is_cloud_deployed": True,
+            "uses_sampling": False,
+            "uses_sequential_thinking": False,
+            "tools_include_filesystem": False,
+            "tools_make_external_requests": True,
+            "stadt_zuerich_context": True,
+            "schulamt_context": False,
+            "volksschule_context": False,
+            "enterprise_context": False,
+            "sdk_language": "Python",
+            "data_source": {"is_swiss_open_data": True},
+        }
+        results = evaluate_catalog(profile, CHECKS_DIR)
+        assert results["OBS-006"]["applicable"] is True
 
 
 class TestWriteCapableSchemaMigration:
@@ -397,6 +489,33 @@ class TestWriteCapableSchemaMigration:
         # cloud_oauth has write_capable=True → HITL-005 must apply.
         results = evaluate_catalog(cloud_oauth_profile, CHECKS_DIR)
         assert results["HITL-005"]["applicable"] is True
+
+    def test_legacy_profile_without_is_cloud_deployed_fails_loudly(self):
+        """A profile that lacks `is_cloud_deployed` must error rather
+        than silently default to False — Issue #16 design choice.
+        """
+        legacy_profile = {
+            "transport": "stdio-only",
+            "auth_model": "none",
+            "data_class": "Public Open Data",
+            "write_capable": False,
+            "deployment": ["local-stdio"],
+            # NOTE: no is_cloud_deployed
+            "uses_sampling": False,
+            "uses_sequential_thinking": False,
+            "tools_include_filesystem": False,
+            "tools_make_external_requests": False,
+            "stadt_zuerich_context": False,
+            "schulamt_context": False,
+            "volksschule_context": False,
+            "enterprise_context": False,
+            "sdk_language": "Python",
+            "data_source": {"is_swiss_open_data": False},
+        }
+        results = evaluate_catalog(legacy_profile, CHECKS_DIR)
+        # OBS-006 evaluates `is_cloud_deployed == true` — must error
+        assert results["OBS-006"]["applicable"] is False
+        assert results["OBS-006"]["reason"].startswith("unknown-field")
 
     def test_legacy_profile_with_only_write_access_fails_loudly(self):
         # If a user provides a legacy profile (write_access only, no

--- a/tests/test_notion_sync.py
+++ b/tests/test_notion_sync.py
@@ -1,0 +1,110 @@
+# -*- coding: utf-8 -*-
+"""Tests for audit-notion-sync.py — only the pure profile-builder logic.
+
+Network-dependent code paths (Notion HTTP) are out of scope for this
+suite; they're integration-tested manually via the `health` subcommand.
+
+The build_profile derivation got more complex in issue #16 (added
+is_cloud_deployed), so a small unit test guards against drift.
+"""
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+def _load_sync_module():
+    """audit-notion-sync.py uses a hyphen in its filename, so we load it
+    via importlib instead of `import audit_notion_sync`.
+    """
+    spec = importlib.util.spec_from_file_location(
+        "audit_notion_sync",
+        REPO_ROOT / "audit-notion-sync.py",
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(scope="module")
+def sync_mod():
+    return _load_sync_module()
+
+
+def _props(
+    transport="dual",
+    auth="none",
+    data_class="Public Open Data",
+    write="read-only",
+    deployment=("local-stdio",),
+    org=(),
+):
+    """Build a minimal Notion-shape props dict the builder expects."""
+    def select(value):
+        return {"select": {"name": value}} if value else {"select": None}
+
+    def multi_select(values):
+        return {"multi_select": [{"name": v} for v in values]}
+
+    return {
+        "Transport": select(transport),
+        "Auth-Modell": select(auth),
+        "Datenklasse": select(data_class),
+        "Schreibzugriff": select(write),
+        "Deployment": multi_select(deployment),
+        "Org-Kontext": multi_select(org),
+    }
+
+
+class TestIsCloudDeployedDerivation:
+    """Issue #16: the sync derives `is_cloud_deployed` from the
+    `deployment` multi_select.
+    """
+
+    def test_local_stdio_only_is_false(self, sync_mod):
+        profile = sync_mod.build_profile(_props(deployment=("local-stdio",)))
+        assert profile["is_cloud_deployed"] is False
+
+    def test_railway_only_is_true(self, sync_mod):
+        profile = sync_mod.build_profile(_props(deployment=("Railway",)))
+        assert profile["is_cloud_deployed"] is True
+
+    def test_local_plus_cloud_is_true(self, sync_mod):
+        profile = sync_mod.build_profile(
+            _props(deployment=("local-stdio", "Railway")),
+        )
+        assert profile["is_cloud_deployed"] is True
+
+    def test_docker_counts_as_cloud(self, sync_mod):
+        # Docker is non-local for the purposes of the cloud-deploy gate.
+        profile = sync_mod.build_profile(_props(deployment=("Docker",)))
+        assert profile["is_cloud_deployed"] is True
+
+    def test_empty_deployment_defaults_to_local(self, sync_mod):
+        # Empty multi_select → defaults to ["local-stdio"] in build_profile.
+        profile = sync_mod.build_profile(_props(deployment=()))
+        assert profile["deployment"] == ["local-stdio"]
+        assert profile["is_cloud_deployed"] is False
+
+
+class TestProfileShape:
+    def test_required_fields_present(self, sync_mod):
+        profile = sync_mod.build_profile(_props())
+        for field in (
+            "transport", "auth_model", "data_class", "write_capable",
+            "deployment", "is_cloud_deployed", "uses_sampling",
+            "tools_make_external_requests", "data_source",
+        ):
+            assert field in profile, f"missing field {field}"
+
+    def test_write_capable_derived_from_schreibzugriff(self, sync_mod):
+        ro = sync_mod.build_profile(_props(write="read-only"))
+        wr = sync_mod.build_profile(_props(write="write-capable"))
+        assert ro["write_capable"] is False
+        assert wr["write_capable"] is True


### PR DESCRIPTION
## Summary

Closes #16.

The canonical evaluator (#6) had identified 9 checks that compared the **list** field `deployment` to a **string literal**:

```yaml
applies_when: 'deployment != "local-stdio"'
```

Python's `eval` silently coerced this to `True` for any non-empty list, so these 9 checks fired as applicable for **every** server profile — silently inflating findings counts.

## Decision (Option C from issue body)

Introduce a derived boolean profile field `is_cloud_deployed`. Semantic: `true` iff the `deployment` list contains any entry other than `"local-stdio"`.

| Alternative | Why not |
|---|---|
| Positive disjunction `deployment.includes("Railway") or ...` | verbose, list of cloud targets duplicated 9 times |
| `not (deployment == ["local-stdio"])` (DSL extension) | DSL change, list-literal grammar |
| **`is_cloud_deployed == true`** ✅ | shorter, clear intent, consistent with `write_capable`/`uses_sampling`/etc. |

## What changed

### Profile schema
- **`audit-notion-sync.py build_profile`** — derives `is_cloud_deployed` automatically from the Notion `Deployment` multi-select. Notion-tracker UX unchanged (single source of truth stays the multi-select).
- **`portfolio.example.yaml`** — both example servers now include `is_cloud_deployed`.
- **`SKILL.md`** profile YAML example — added the field with an explanatory comment.

### 9 check migrations
| Check | Old | New |
|---|---|---|
| `OBS-005` | `deployment != "local-stdio" and data_class != "Public Open Data"` | `is_cloud_deployed == true and data_class != "Public Open Data"` |
| `OBS-006` | `deployment != "local-stdio"` | `is_cloud_deployed == true` |
| `SCALE-003` | `(transport == "HTTP/SSE" or transport == "dual") and deployment != "local-stdio"` | `(transport == "HTTP/SSE" or transport == "dual") and is_cloud_deployed == true` |
| `SCALE-004` | `deployment != "local-stdio"` | `is_cloud_deployed == true` |
| `SCALE-006` | `deployment != "local-stdio"` | `is_cloud_deployed == true` |
| `SEC-014` | `... or deployment != "local-stdio"` | `... or is_cloud_deployed == true` |
| `SEC-015` | (same) | (same) |
| `SEC-021` | `tools_make_external_requests == true or deployment != "local-stdio"` | `tools_make_external_requests == true or is_cloud_deployed == true` |
| `SEC-022` | `... or deployment != "local-stdio"` | `... or is_cloud_deployed == true` |

### Tests
- **Removed** the `KNOWN_BUGGY_DEPLOYMENT_COMPARISON` set and `test_known_buggy_checks_still_flagged` — the bug is fixed at the source.
- **Added** `TestIsCloudDeployedFlag` (5 cases): `local-stdio`-only skips cloud checks, cloud deployment activates them, SEC-021 OR-arm with `tools_make_external_requests`, dual deployment edge case.
- **Added** `test_no_check_compares_deployment_list_to_string_literal` — sweep over all 68 checks, asserts none re-introduce the anti-pattern.
- **Added** `test_legacy_profile_without_is_cloud_deployed_fails_loudly` — confirms the no-silent-fallback design from #6.
- **NEW** `tests/test_notion_sync.py` (7 cases) — verifies `build_profile` derives `is_cloud_deployed` correctly across single/multi/empty deployment lists.
- **Updated** all three test fixtures (`srgssr_profile`, `zh_education_profile`, `cloud_oauth_profile`) to include the new field.

### Documentation
- **`docs/applies-when-dsl.md`** — anti-pattern section now points to `is_cloud_deployed` as the canonical fix.
- **`CHANGELOG.md`** — Unreleased entry.

## Test plan

- [x] `python -m pytest tests/` — 195 passed (181 → 195, +14 cases)
- [x] `python tools/eval_applicability.py catalog portfolio.example.yaml` — clean run, no type-mismatches
- [x] All 9 previously-buggy checks evaluate cleanly against the srgssr profile (regression test)
- [x] Sweep test confirms no check uses `deployment != "X"` or `deployment == "X"` anymore
- [ ] CI green on Ubuntu + Windows runners

## Out of scope (separate PRs)

- #14 — Profile placeholder detection
- #15 — Audit run-id with timezone


---
_Generated by [Claude Code](https://claude.ai/code/session_01PgYtwRK14HmFwES2PusuHH)_