### PR TITLE
Add Step 7 release automation + pluggable tracker backends

### DIFF
--- a/.claude/commands/audit-mcp.md
+++ b/.claude/commands/audit-mcp.md
@@ -1,7 +1,7 @@
 ---
 description: Audit eines MCP-Servers gegen den mcp-audit-skill v0.5.0-Katalog. Lädt Profil, filtert anwendbare Checks, führt automatisierte Verifikation aus, erzeugt Findings-Stubs und Audit-Report. Funktioniert mit lokalem Skill-Klon oder via WebFetch von GitHub-Raw (Cloud-Modus).
 argument-hint: <repo-url-or-local-path>
-allowed-tools: Bash(git:*), Bash(grep:*), Bash(find:*), Bash(curl:*), Bash(ls:*), Bash(cat:*), Bash(wc:*), Bash(head:*), Bash(tail:*), Bash(awk:*), Bash(sed:*), Bash(jq:*), Bash(test:*), Bash(python:*), Bash(python3:*), Read, Write, Glob, WebFetch
+allowed-tools: Bash(git:*), Bash(gh:*), Bash(grep:*), Bash(find:*), Bash(curl:*), Bash(ls:*), Bash(cat:*), Bash(wc:*), Bash(head:*), Bash(tail:*), Bash(awk:*), Bash(sed:*), Bash(jq:*), Bash(test:*), Bash(python:*), Bash(python3:*), Read, Write, Glob, WebFetch
 ---
 
 # /audit-mcp — MCP-Server Audit-Workflow
@@ -266,6 +266,66 @@ Der Output landet als `$OUTPUT_DIR/audit-report.md`. Sektionen werden aus `summa
 7. **Audit-Metadata** — Skill-Version, Catalog-Version, Policy.
 
 **Output Schritt 6:** Pfad zum Report-File. Plus Klartext-Empfehlung: «Production-Ready ja/nein, nächste Schritte sind: ...».
+
+---
+
+### Schritt 7 — Release-Vorschlag (nur bei `production_ready: true`)
+
+Dieser Schritt läuft **nur**, wenn `summary.json` `production_ready: true` zeigt. Bei offenen `critical`/`high`-Findings überspringst du Schritt 7 vollständig und weist den User auf die Blocker hin.
+
+**7.1 Vorschlag generieren** (modifiziert nichts):
+
+```bash
+python "$SKILL_BASE/tools/propose_release.py" propose \
+    "$OUTPUT_DIR" "$TARGET" \
+    --bump patch \
+    --format json
+# exit 0 = Vorschlag, exit 2 = nicht production-ready
+```
+
+Output enthält `current_version`, `next_version`, `changelog_entry`, vorgeschlagene `git tag`/`gh release`-Befehle.
+
+**7.2 Vorschlag dem User präsentieren** und auf explizite Bestätigung warten. Format:
+
+```
+Audit zeigt production_ready=true. Vorschlag:
+  Current version : 0.4.2 (from pyproject)
+  Next version    : 0.4.3 (--bump patch)
+  CHANGELOG entry : <gekürzt>
+  
+Soll ich apply (CHANGELOG schreiben + git tag + draft GH release)?
+```
+
+**Frage zwingend nach** — keinen Apply-Modus ohne explizites OK des Users. Erlaube auch den User-Override `--bump minor` / `--bump major` / `--next-version 1.0.0`.
+
+**7.3 Apply nach Bestätigung:**
+
+```bash
+python "$SKILL_BASE/tools/propose_release.py" apply \
+    "$OUTPUT_DIR" "$TARGET" \
+    --bump <wie bestätigt> \
+    --notes "<vom User oder aus Audit-Findings abgeleitet>" \
+    --gh-release
+```
+
+Apply schreibt CHANGELOG, committet, erzeugt einen annotated git tag und optional einen Draft-GitHub-Release. **Pusht nicht** — das macht der User selbst.
+
+**7.4 Tracker-Update:**
+
+```bash
+# Default-Backend ist CSV (lokal). User kann via --backend notion umschalten,
+# falls NOTION_TOKEN gesetzt ist.
+python "$SKILL_BASE/tools/tracker_sync.py" update "$SERVER_NAME" \
+    --from-summary "$OUTPUT_DIR/summary.json" \
+    --set "audit_status=Released" \
+    --set "released_version=$NEXT_VERSION"
+```
+
+Die Backend-Wahl ist user-konfigurierbar via `MCP_AUDIT_TRACKER_BACKEND` (`csv`/`notion`) und `MCP_AUDIT_TRACKER_PATH` (für CSV). Wenn der User Notion nutzt: `--backend notion` plus `NOTION_TOKEN` im Environment.
+
+**Output Schritt 7:** Tag-Name, CHANGELOG-Diff (kurz), Tracker-Backend + aktualisierte Felder, sowie die nächsten manuellen Schritte (`git push origin HEAD`, `git push origin <tag>`, Draft-Release veröffentlichen).
+
+Wenn der Server **nicht** production-ready ist: nenne die `blocking_findings` aus `summary.json` und stoppe nach Schritt 6.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,29 @@ Versionierung: [Semantic Versioning](https://semver.org/lang/de/).
 
 ## [Unreleased]
 
-_(noch keine Änderungen seit v1.0.0)_
+### Hinzugefügt — Release-Automatisierung für auditierte Server (Schritt 7)
+
+Nach den Audit-/Remediation-Schleifen schlägt der Skill jetzt automatisch einen versionierten Release des **auditierten MCP-Servers** vor (nicht des Skill-Repos), inklusive CHANGELOG-Eintrag und GitHub-Release-Draft.
+
+- **`tools/propose_release.py`** — `propose`-Modus generiert Vorschlag (semver-Bump, CHANGELOG-Entry, Tag- und Release-Befehle) und modifiziert nichts; `apply`-Modus schreibt CHANGELOG, committet, erzeugt annotated git tag und optional einen `gh release --draft`. Pusht **nie** automatisch — Maintainer-Verantwortung.
+- **Production-Ready-Gate** — `propose`/`apply` weigern sich, wenn `summary.production_ready == false`. `--force` existiert für dokumentierte Hotfix-Eskalationen.
+- **Versions-Detection** — liest `pyproject.toml`/`package.json`/letztes git-Tag (in dieser Reihenfolge); ändert Version-Strings in den Manifesten **nicht** (Bump-Konvention liegt beim Projekt).
+- **CHANGELOG-Integration** — `## [Unreleased]`-Block bleibt erhalten; neue Einträge werden direkt darunter eingefügt. Audit-Metadaten (run-id, skill_version, catalog_hash, by_status) werden im Eintrag persistiert für Audit-Trail.
+- **SKILL.md Schritt 7** + **Slash-Command Schritt 7** dokumentieren den verbindlichen Vorschlag-Bestätigung-Apply-Workflow. Slash-Command darf Apply **nur nach explizitem OK** des Users ausführen.
+- **23 neue pytest cases** (`tests/test_propose_release.py`).
+
+### Hinzugefügt — Pluggable Tracker-Backends (Notion + CSV)
+
+Der bisherige `audit-notion-sync.py` band den Skill an Notion. Neue Abstraktion erlaubt anderen Datenbanken-Backends, damit alle Auditoren den Skill nutzen können — nicht nur die mit Notion-Workspace.
+
+- **`tools/tracker_sync.py`** — pluggable Backend-Layer mit gemeinsamer `TrackerBackend.get/update/list_all`-Schnittstelle. Aktuelle Adapter: `csv` (zero-deps, Default) und `notion` (wraps die existierende API). Backend-Wahl via `--backend` oder `MCP_AUDIT_TRACKER_BACKEND`-Env.
+- **CSV-Backend** — schreibt `tracker.csv` mit kanonischen Spalten (`server_name`, `audit_status`, `findings`, `last_audit_run`, `last_audit_at`, `production_ready`, `released_version`, `notes`). Datei wird beim ersten Schreibzugriff samt Header erzeugt; Updates merge-tolerant.
+- **Notion-Backend** — selbe Field-Semantik, mappt auf existierende Tracker-Properties plus optional `Released Version`/`Production Ready`/`Last Audit Run/At`. Felder, die in Notion fehlen, werden ignoriert ohne Drama.
+- **`--from-summary`** — zieht `findings`, `production_ready`, `last_audit_run`, `last_audit_at` direkt aus `summary.json` (Single-Source-of-Truth, kein Re-Counting). Ersetzt die manuelle `jq`-Pipeline aus dem alten Workflow.
+- **SKILL.md Schritt 5.2 + 7.3** dokumentieren beide Backends; Anleitung zum Hinzufügen weiterer Adapter (Airtable, Google Sheets) enthalten.
+- **19 neue pytest cases** (`tests/test_tracker_sync.py`).
+
+Test-Total: 255 → 297.
 
 ---
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -77,6 +77,9 @@ Inline-`python3 << 'PYEOF'`-Blöcke crashen auf Windows Git Bash regelmässig du
 | Audit-Report generieren | `python tools/build_report.py <audit_dir>` |
 | Task-Agent-Output verifizieren | `python tools/verify_raw_outputs.py raw/ --expected-ids ID1,ID2` |
 | Task-Agent-Run loggen | `python tools/agent_run_log.py log --meta-path audit-meta.json ...` |
+| Release-Vorschlag (Schritt 7) | `python tools/propose_release.py propose <audit_dir> <target_repo>` |
+| Release anwenden (CHANGELOG + Tag) | `python tools/propose_release.py apply <audit_dir> <target_repo> --bump <patch\|minor\|major>` |
+| Tracker-Update (CSV/Notion) | `python tools/tracker_sync.py update <server> --from-summary <summary.json>` |
 | Pfad zu Native/POSIX konvertieren | `python tools/path_utils.py to-native <path>` |
 
 Wenn ein Audit ein Snippet braucht das hier nicht abgedeckt ist: erst Issue im Skill-Repo öffnen, dann Helper-Script bauen, dann verwenden. **Inline-Heredoc ist der Anti-Pattern, der nicht-reproduzierbare Audits erzeugt.**
@@ -439,20 +442,30 @@ Verwendet `templates/finding.md`:
 S (< 1d) | M (1-3d) | L (1-2w) | XL (>2w)
 ```
 
-### 5.2 Findings-Anzahl zurück in Audit Tracker
+### 5.2 Findings-Anzahl zurück in den Audit-Tracker
 
-Nach Abschluss des Audits wird die `Findings`-Spalte in der Notion-Karte aktualisiert. Der Wert MUSS aus `summary.json` gelesen werden, niemals neu gezählt:
+Nach Abschluss des Audits wird die `Findings`-Spalte im Tracker aktualisiert. Der Wert MUSS aus `summary.json` gelesen werden, niemals neu gezählt:
 
 ```bash
-# Korrekt: Single-Source-of-Truth
-total_findings=$(jq '.findings.expected_count' audits/<run>/summary.json)
-update_audit_tracker --server "$name" --findings "$total_findings" --status "Findings dokumentiert"
+# Korrekt: Single-Source-of-Truth via tracker_sync
+python "$SKILL_BASE/tools/tracker_sync.py" update "$name" \
+    --from-summary "audits/<run>/summary.json" \
+    --set "audit_status=Findings dokumentiert"
 ```
 
 ```python
 # FALSCH: separate Re-Computation — riskiert Drift gegen Step 5/6
 total_findings = sum(1 for r in check_runs if r.status in ("fail", "partial"))
 ```
+
+**Backend-Auswahl:** Der Tracker-Sync ist pluggable, damit der Skill nicht an Notion gebunden ist:
+
+| Backend | Aktivierung | Verwendung |
+|---|---|---|
+| `csv` (Default) | `--backend csv --csv-path tracker.csv` oder `MCP_AUDIT_TRACKER_PATH=...` | Lokal, zero-deps. Perfekt für User ohne Cloud-DB. |
+| `notion` | `--backend notion`, plus `NOTION_TOKEN` (+ optional `NOTION_AUDIT_DB_ID`) | Stadt-Zürich-Setup; bestehender Audit-Tracker. |
+
+Das CSV-Backend erzeugt die Datei beim ersten Schreibzugriff inklusive Header-Zeile. Felder sind backend-agnostisch: `server_name`, `audit_status`, `findings`, `last_audit_run`, `last_audit_at`, `production_ready`, `released_version`, `notes`. Wer Airtable oder Google Sheets braucht, fügt einen Adapter in `tools/tracker_sync.py` hinzu — Interface ist `TrackerBackend.get/update/list_all`.
 
 ### 5.3 Audit-Status-Transition
 
@@ -497,6 +510,71 @@ jq -r '.blocking_findings[]' audits/<run>/summary.json
 - **GL / KI-Fachgruppe:** Deutsch, Executive Summary + Findings-Tabelle reichen
 - **Entwickler / Maintainer:** Deutsch oder Englisch, vollständiger Detail-Report
 - **Externe Auditoren / Compliance:** Englisch, vollständig + Profile-Snapshot
+
+---
+
+## Schritt 7: Release-Vorschlag (nur bei `production_ready: true`)
+
+**Ziel:** Wenn der Server nach den Audit-/Remediation-Schleifen production-ready ist, einen versionierten Release des **auditierten Server-Repos** vorschlagen — inklusive CHANGELOG-Eintrag und GitHub-Release-Draft. Nicht für das Skill-Repo selbst.
+
+Schritt 7 läuft nur, wenn `summary.production_ready == true` (keine offenen `critical`/`high`-Fails). Bei offenen Blockern wird der Release verweigert; das ist Absicht.
+
+### 7.1 Release-Vorschlag generieren
+
+```bash
+# Liest summary.json, ermittelt aktuelle Version (pyproject.toml /
+# package.json / git tag) und schlägt einen CHANGELOG-Eintrag vor.
+python "$SKILL_BASE/tools/propose_release.py" propose \
+    "$OUTPUT_DIR" "$TARGET" \
+    --bump patch \
+    --notes "Schliesst HITL-005 und SEC-007. Audit run-id wie unten." \
+    --format json
+# exit 0 = Vorschlag generiert, exit 2 = nicht production-ready (mit Begründung)
+```
+
+Der Vorschlag enthält: aktuelle Version + Quelle (`pyproject` / `package` / `git`), nächste Version (semver-Bump), CHANGELOG-Diff, vorgeschlagene `git tag`/`gh release`-Befehle und die Audit-Metadaten (run-id, skill_version, catalog_hash, by_status). **Im Propose-Modus wird nichts geschrieben** — der User sieht den Vorschlag und bestätigt.
+
+### 7.2 Release anwenden (nach Bestätigung)
+
+```bash
+# Schreibt CHANGELOG, committet (chore(release): vX.Y.Z), erzeugt
+# annotated git tag, optional gh release --draft. Nichts wird gepusht.
+python "$SKILL_BASE/tools/propose_release.py" apply \
+    "$OUTPUT_DIR" "$TARGET" \
+    --bump patch \
+    --notes "..." \
+    --gh-release
+```
+
+Der Apply-Modus ist bewusst defensiv: kein `git push`, kein non-draft Release. Der User entscheidet, wann der Tag und der Release veröffentlicht werden. Die Skill-Verantwortung endet beim Draft.
+
+**Wichtig:** Wenn `pyproject.toml` oder `package.json` eine Version pinnen, ist diese die kanonische Quelle. Der Skill ändert diese Files **nicht** — der Maintainer bumpt die Version-Zahl im Manifest selbst, bevor er den Tag pushed. Begründung: Skill kennt die Bump-Konvention des Projekts nicht (pre-release tags, scope-prefix, etc.).
+
+### 7.3 Tracker-Update nach Release
+
+Nach dem Release wird der Tracker-Eintrag aktualisiert — backend-agnostisch via `tracker_sync.py`:
+
+```bash
+# Default: CSV (lokal, zero-deps)
+python "$SKILL_BASE/tools/tracker_sync.py" update "$SERVER_NAME" \
+    --from-summary "$OUTPUT_DIR/summary.json" \
+    --set "audit_status=Released" \
+    --set "released_version=$NEXT_VERSION"
+
+# Notion (alternativ, falls NOTION_TOKEN gesetzt)
+python "$SKILL_BASE/tools/tracker_sync.py" --backend notion update "$SERVER_NAME" \
+    --from-summary "$OUTPUT_DIR/summary.json" \
+    --set "audit_status=Released" \
+    --set "released_version=$NEXT_VERSION"
+```
+
+`--from-summary` zieht `findings`, `production_ready`, `last_audit_run` und `last_audit_at` automatisch aus der Audit-Summary — Single-Source-of-Truth, kein Re-Counting. Felder, die im Notion-Tracker fehlen (z.B. `Released Version`), werden ohne Drama übersprungen, wenn sie via Property-Map nicht definiert sind.
+
+### 7.4 Anti-Patterns
+
+- **Release ohne grünen Audit:** `propose_release.py` weigert sich. `--force` existiert für absolute Notfälle (z.B. Hotfix-Release mit dokumentierter Risiko-Akzeptanz), aber das ist eine Eskalation, nicht Routine.
+- **Skill bumpt die Manifest-Version automatisch:** macht er nicht. Versionen in `pyproject.toml`/`package.json` sind Maintainer-Verantwortung; Skill schreibt nur CHANGELOG + Tag.
+- **`git push` automatisch:** macht der Skill nicht. Apply-Modus bleibt lokal, Pushen ist eine bewusste Maintainer-Aktion.
 
 ---
 

--- a/tests/test_propose_release.py
+++ b/tests/test_propose_release.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import json
 import subprocess
+import sys
 from pathlib import Path
 
 import pytest
@@ -234,15 +235,16 @@ class TestChangelog:
 # CLI behaviour: production-ready gating
 # ---------------------------------------------------------------------------
 
-PROPOSE_BIN = ["python3", "tools/propose_release.py"]
+PROPOSE_BIN = [sys.executable, "tools/propose_release.py"]
 
 
 def _run_propose(args: list[str], cwd: Path) -> subprocess.CompletedProcess:
+    import os
     return subprocess.run(
         PROPOSE_BIN + args,
         cwd=str(Path(__file__).resolve().parent.parent),
         capture_output=True, text=True,
-        env={**__import__("os").environ, "PYTHONUTF8": "1"},
+        env={**os.environ, "PYTHONUTF8": "1"},
     )
 
 

--- a/tests/test_propose_release.py
+++ b/tests/test_propose_release.py
@@ -1,0 +1,302 @@
+# -*- coding: utf-8 -*-
+"""Tests for tools/propose_release.py — semver, CHANGELOG insertion,
+production-ready gating, and proposal output structure."""
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from tools.propose_release import (
+    AuditSummary,
+    ReleaseError,
+    bump_version,
+    detect_current_version,
+    insert_changelog_entry,
+    render_changelog_entry,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def audit_dir(tmp_path: Path) -> Path:
+    d = tmp_path / "audit"
+    d.mkdir()
+    summary = {
+        "audit_meta": {
+            "server_name": "example-mcp",
+            "run_id": "2026-05-09T120000-Z-example-mcp",
+            "skill_version": "1.0.0",
+            "catalog_hash": "abcdef0123456789" * 4,  # 64 chars
+            "started_at": "2026-05-09T12:00:00Z",
+        },
+        "totals": {
+            "checks_evaluated": 20,
+            "applicable": 20,
+            "by_status": {"pass": 18, "fail": 0, "partial": 0, "todo": 2, "n/a": 0},
+            "by_severity_among_findings": {"critical": 0, "high": 0,
+                                           "medium": 0, "low": 0},
+        },
+        "findings": {
+            "policy": "fail-or-partial",
+            "expected_count": 0,
+            "expected_ids": [],
+            "details": [],
+        },
+        "production_ready": True,
+        "blocking_findings": [],
+    }
+    (d / "summary.json").write_text(json.dumps(summary), encoding="utf-8")
+    return d
+
+
+@pytest.fixture
+def failing_audit_dir(tmp_path: Path) -> Path:
+    d = tmp_path / "audit_fail"
+    d.mkdir()
+    summary = {
+        "audit_meta": {"server_name": "broken-mcp", "run_id": "rid"},
+        "totals": {
+            "checks_evaluated": 5,
+            "applicable": 5,
+            "by_status": {"pass": 2, "fail": 3, "partial": 0, "todo": 0, "n/a": 0},
+            "by_severity_among_findings": {"critical": 1, "high": 2,
+                                           "medium": 0, "low": 0},
+        },
+        "findings": {"policy": "fail-or-partial", "expected_count": 3,
+                     "expected_ids": ["SEC-001", "SEC-002", "SEC-003"],
+                     "details": []},
+        "production_ready": False,
+        "blocking_findings": ["SEC-001", "SEC-002", "SEC-003"],
+    }
+    (d / "summary.json").write_text(json.dumps(summary), encoding="utf-8")
+    return d
+
+
+# ---------------------------------------------------------------------------
+# AuditSummary
+# ---------------------------------------------------------------------------
+
+class TestAuditSummary:
+    def test_loads_from_dir(self, audit_dir: Path) -> None:
+        s = AuditSummary.from_dir(audit_dir)
+        assert s.production_ready is True
+        assert s.blocking_findings == []
+        assert s.server_name == "example-mcp"
+        assert s.run_id.startswith("2026-05-09T")
+
+    def test_missing_summary_raises(self, tmp_path: Path) -> None:
+        with pytest.raises(ReleaseError, match="summary.json not found"):
+            AuditSummary.from_dir(tmp_path)
+
+    def test_meta_overrides_audit_meta(self, audit_dir: Path) -> None:
+        # audit-meta.json beats inline audit_meta on overlap.
+        (audit_dir / "audit-meta.json").write_text(
+            json.dumps({"server_name": "from-meta", "run_id": "from-meta-rid",
+                        "skill_version": "9.9.9"}),
+            encoding="utf-8",
+        )
+        s = AuditSummary.from_dir(audit_dir)
+        assert s.server_name == "from-meta"
+        assert s.skill_version == "9.9.9"
+
+
+# ---------------------------------------------------------------------------
+# Semver bump
+# ---------------------------------------------------------------------------
+
+class TestBumpVersion:
+    @pytest.mark.parametrize("current,bump,expected", [
+        ("1.2.3", "patch", "1.2.4"),
+        ("1.2.3", "minor", "1.3.0"),
+        ("1.2.3", "major", "2.0.0"),
+        ("0.0.0", "patch", "0.0.1"),
+        ("v1.0.0", "minor", "1.1.0"),  # leading v tolerated
+        ("1.0.0-rc1", "patch", "1.0.1"),  # pre-release suffix dropped
+    ])
+    def test_bumps(self, current: str, bump: str, expected: str) -> None:
+        assert bump_version(current, bump) == expected
+
+    def test_invalid_bump(self) -> None:
+        with pytest.raises(ReleaseError, match="Invalid bump"):
+            bump_version("1.0.0", "bogus")
+
+    def test_non_semver_raises(self) -> None:
+        with pytest.raises(ReleaseError, match="not semver-shaped"):
+            bump_version("foo.bar", "patch")
+
+
+# ---------------------------------------------------------------------------
+# Version detection
+# ---------------------------------------------------------------------------
+
+class TestDetectCurrentVersion:
+    def test_pyproject_wins(self, tmp_path: Path) -> None:
+        (tmp_path / "pyproject.toml").write_text(
+            '[project]\nname = "x"\nversion = "1.2.3"\n',
+            encoding="utf-8",
+        )
+        v, src = detect_current_version(tmp_path)
+        assert (v, src) == ("1.2.3", "pyproject")
+
+    def test_package_json_fallback(self, tmp_path: Path) -> None:
+        (tmp_path / "package.json").write_text(
+            json.dumps({"name": "x", "version": "0.4.0"}),
+            encoding="utf-8",
+        )
+        v, src = detect_current_version(tmp_path)
+        assert (v, src) == ("0.4.0", "package")
+
+    def test_none_when_no_metadata(self, tmp_path: Path) -> None:
+        v, src = detect_current_version(tmp_path)
+        assert src in ("none", "git")  # may pick up git tag if tmp is in a repo
+
+    def test_pyproject_only_inside_project_section(self, tmp_path: Path) -> None:
+        (tmp_path / "pyproject.toml").write_text(
+            '[tool.poetry]\nversion = "9.9.9"\n[project]\nversion = "1.0.0"\n',
+            encoding="utf-8",
+        )
+        v, _ = detect_current_version(tmp_path)
+        assert v == "1.0.0"
+
+
+# ---------------------------------------------------------------------------
+# CHANGELOG rendering / insertion
+# ---------------------------------------------------------------------------
+
+class TestChangelog:
+    def _summary(self) -> AuditSummary:
+        return AuditSummary(
+            production_ready=True,
+            blocking_findings=[],
+            by_status={"pass": 18, "fail": 0, "partial": 0, "todo": 2, "n/a": 0},
+            by_severity={},
+            server_name="example-mcp",
+            run_id="2026-05-09T120000-Z-example-mcp",
+            skill_version="1.0.0",
+            catalog_hash="abcdef" * 10,
+            started_at="2026-05-09T12:00:00Z",
+            findings_count=0,
+        )
+
+    def test_render_includes_audit_metadata(self) -> None:
+        entry = render_changelog_entry("1.2.3", self._summary(),
+                                       notes="Added X.", today="2026-05-09")
+        assert "## [v1.2.3] — 2026-05-09" in entry
+        assert "Added X." in entry
+        assert "Production-ready:" in entry
+        assert "2026-05-09T120000-Z-example-mcp" in entry
+        assert "18 pass" in entry
+
+    def test_render_without_notes(self) -> None:
+        entry = render_changelog_entry("0.1.0", self._summary(), None, "2026-01-01")
+        assert "## [v0.1.0]" in entry
+        assert "### Audit verification" in entry
+
+    def test_insert_new_file(self, tmp_path: Path) -> None:
+        path = tmp_path / "CHANGELOG.md"
+        new_text, original = insert_changelog_entry(path, "## [v0.1.0]\nfoo\n")
+        assert original == ""
+        assert "# Changelog" in new_text
+        assert "## [v0.1.0]" in new_text
+
+    def test_insert_with_unreleased(self, tmp_path: Path) -> None:
+        path = tmp_path / "CHANGELOG.md"
+        path.write_text(
+            "# Changelog\n\n## [Unreleased]\n\n_no changes_\n\n"
+            "## [v0.1.0] — 2026-01-01\n\n- initial\n",
+            encoding="utf-8",
+        )
+        entry = "## [v0.2.0] — 2026-05-09\n\n- new\n"
+        new_text, _ = insert_changelog_entry(path, entry)
+
+        # Unreleased preserved, new entry above 0.1.0.
+        assert new_text.index("[Unreleased]") < new_text.index("[v0.2.0]")
+        assert new_text.index("[v0.2.0]") < new_text.index("[v0.1.0]")
+
+    def test_insert_no_unreleased(self, tmp_path: Path) -> None:
+        path = tmp_path / "CHANGELOG.md"
+        path.write_text(
+            "# Changelog\n\n## [v0.1.0] — 2026-01-01\n\n- initial\n",
+            encoding="utf-8",
+        )
+        entry = "## [v0.2.0] — 2026-05-09\n\n- new\n"
+        new_text, _ = insert_changelog_entry(path, entry)
+        assert new_text.index("[v0.2.0]") < new_text.index("[v0.1.0]")
+
+
+# ---------------------------------------------------------------------------
+# CLI behaviour: production-ready gating
+# ---------------------------------------------------------------------------
+
+PROPOSE_BIN = ["python3", "tools/propose_release.py"]
+
+
+def _run_propose(args: list[str], cwd: Path) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        PROPOSE_BIN + args,
+        cwd=str(Path(__file__).resolve().parent.parent),
+        capture_output=True, text=True,
+        env={**__import__("os").environ, "PYTHONUTF8": "1"},
+    )
+
+
+class TestCli:
+    def test_propose_blocks_when_not_ready(self, failing_audit_dir: Path,
+                                           tmp_path: Path) -> None:
+        target = tmp_path / "target"
+        target.mkdir()
+        (target / "pyproject.toml").write_text(
+            '[project]\nversion = "0.1.0"\n', encoding="utf-8",
+        )
+        result = _run_propose(
+            ["propose", str(failing_audit_dir), str(target),
+             "--format", "json"],
+            cwd=tmp_path,
+        )
+        assert result.returncode == 2, result.stderr
+        out = json.loads(result.stdout)
+        assert out["ok"] is False
+        assert out["reason"] == "not_production_ready"
+        assert "SEC-001" in out["blocking_findings"]
+
+    def test_propose_emits_proposal_when_ready(self, audit_dir: Path,
+                                               tmp_path: Path) -> None:
+        target = tmp_path / "target"
+        target.mkdir()
+        (target / "pyproject.toml").write_text(
+            '[project]\nversion = "0.4.2"\n', encoding="utf-8",
+        )
+        result = _run_propose(
+            ["propose", str(audit_dir), str(target),
+             "--format", "json", "--bump", "minor",
+             "--today", "2026-05-09"],
+            cwd=tmp_path,
+        )
+        assert result.returncode == 0, result.stderr
+        out = json.loads(result.stdout)
+        assert out["ok"] is True
+        assert out["current_version"] == "0.4.2"
+        assert out["next_version"] == "0.5.0"
+        assert "## [v0.5.0]" in out["changelog_entry"]
+        # Working tree must be untouched.
+        assert not (target / "CHANGELOG.md").exists()
+
+    def test_propose_force_overrides_gating(self, failing_audit_dir: Path,
+                                            tmp_path: Path) -> None:
+        target = tmp_path / "target"
+        target.mkdir()
+        (target / "pyproject.toml").write_text(
+            '[project]\nversion = "0.1.0"\n', encoding="utf-8",
+        )
+        result = _run_propose(
+            ["propose", str(failing_audit_dir), str(target),
+             "--format", "json", "--force", "--today", "2026-05-09"],
+            cwd=tmp_path,
+        )
+        assert result.returncode == 0, result.stderr

--- a/tests/test_tracker_sync.py
+++ b/tests/test_tracker_sync.py
@@ -1,0 +1,244 @@
+# -*- coding: utf-8 -*-
+"""Tests for tools/tracker_sync.py — focus on the CSV backend (zero-deps)
+and the backend resolver. Notion is exercised only via constructor / env
+plumbing; real API calls are not mocked here."""
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from tools.tracker_sync import (
+    CANONICAL_FIELDS,
+    CsvBackend,
+    NotionBackend,
+    TrackerError,
+    TrackerRecord,
+    get_backend,
+)
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+# ---------------------------------------------------------------------------
+# CsvBackend
+# ---------------------------------------------------------------------------
+
+class TestCsvBackend:
+    def test_creates_file_with_header(self, tmp_path: Path) -> None:
+        path = tmp_path / "tracker.csv"
+        backend = CsvBackend(path)
+        assert backend.list_all() == []
+        text = path.read_text(encoding="utf-8")
+        for f in CANONICAL_FIELDS:
+            assert f in text
+
+    def test_insert_then_read(self, tmp_path: Path) -> None:
+        backend = CsvBackend(tmp_path / "t.csv")
+        backend.update("server-a", {"audit_status": "In Audit", "findings": 3})
+
+        record = backend.get("server-a")
+        assert record is not None
+        assert record.audit_status == "In Audit"
+        assert record.findings == 3
+        assert record.server_name == "server-a"
+
+    def test_update_merges_partial(self, tmp_path: Path) -> None:
+        backend = CsvBackend(tmp_path / "t.csv")
+        backend.update("srv", {"audit_status": "In Audit", "findings": 5})
+        backend.update("srv", {"production_ready": True,
+                                "released_version": "1.0.0"})
+
+        record = backend.get("srv")
+        assert record is not None
+        assert record.audit_status == "In Audit"  # preserved
+        assert record.findings == 5  # preserved
+        assert record.production_ready is True
+        assert record.released_version == "1.0.0"
+
+    def test_unknown_field_raises(self, tmp_path: Path) -> None:
+        backend = CsvBackend(tmp_path / "t.csv")
+        with pytest.raises(TrackerError, match="Unknown field"):
+            backend.update("srv", {"bogus": "x"})
+
+    def test_get_missing_returns_none(self, tmp_path: Path) -> None:
+        backend = CsvBackend(tmp_path / "t.csv")
+        assert backend.get("nope") is None
+
+    def test_list_all_returns_all_servers(self, tmp_path: Path) -> None:
+        backend = CsvBackend(tmp_path / "t.csv")
+        backend.update("a", {"findings": 1})
+        backend.update("b", {"findings": 2})
+        backend.update("c", {"findings": 0, "production_ready": True})
+
+        records = backend.list_all()
+        names = sorted(r.server_name for r in records)
+        assert names == ["a", "b", "c"]
+
+    def test_round_trip_production_ready_bool(self, tmp_path: Path) -> None:
+        backend = CsvBackend(tmp_path / "t.csv")
+        backend.update("a", {"production_ready": True})
+        backend.update("b", {"production_ready": False})
+
+        assert backend.get("a").production_ready is True
+        assert backend.get("b").production_ready is False
+
+
+# ---------------------------------------------------------------------------
+# Backend resolver
+# ---------------------------------------------------------------------------
+
+class TestGetBackend:
+    def test_default_is_csv(self, monkeypatch: pytest.MonkeyPatch,
+                            tmp_path: Path) -> None:
+        monkeypatch.delenv("MCP_AUDIT_TRACKER_BACKEND", raising=False)
+        monkeypatch.delenv("MCP_AUDIT_TRACKER_PATH", raising=False)
+        monkeypatch.chdir(tmp_path)
+        backend = get_backend(None)
+        assert backend.name == "csv"
+
+    def test_explicit_csv_with_path(self, tmp_path: Path) -> None:
+        backend = get_backend("csv", csv_path=str(tmp_path / "x.csv"))
+        assert backend.name == "csv"
+        assert isinstance(backend, CsvBackend)
+        assert backend.path == tmp_path / "x.csv"
+
+    def test_csv_path_from_env(self, monkeypatch: pytest.MonkeyPatch,
+                               tmp_path: Path) -> None:
+        target = tmp_path / "env.csv"
+        monkeypatch.setenv("MCP_AUDIT_TRACKER_PATH", str(target))
+        backend = get_backend("csv")
+        assert isinstance(backend, CsvBackend)
+        assert backend.path == target
+
+    def test_notion_requires_token(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("NOTION_TOKEN", raising=False)
+        with pytest.raises(TrackerError, match="NOTION_TOKEN"):
+            get_backend("notion")
+
+    def test_notion_constructs_with_token(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("NOTION_TOKEN", "secret_xxx")
+        backend = get_backend("notion")
+        assert isinstance(backend, NotionBackend)
+        assert backend.name == "notion"
+        # Default DB id falls back when env not set.
+        assert backend.db_id
+
+    def test_unknown_backend_raises(self) -> None:
+        with pytest.raises(TrackerError, match="Unknown tracker backend"):
+            get_backend("airtable")
+
+
+# ---------------------------------------------------------------------------
+# TrackerRecord
+# ---------------------------------------------------------------------------
+
+class TestTrackerRecord:
+    def test_to_dict_nonnull_drops_none(self) -> None:
+        record = TrackerRecord(
+            server_name="a",
+            audit_status="In Audit",
+            findings=None,
+            production_ready=True,
+        )
+        d = record.to_dict_nonnull()
+        assert "findings" not in d
+        assert d["server_name"] == "a"
+        assert d["audit_status"] == "In Audit"
+        assert d["production_ready"] is True
+
+
+# ---------------------------------------------------------------------------
+# CLI integration
+# ---------------------------------------------------------------------------
+
+def _run(args: list[str], env: dict[str, str] | None = None) -> subprocess.CompletedProcess:
+    full_env = {**os.environ, "PYTHONUTF8": "1"}
+    if env:
+        full_env.update(env)
+    return subprocess.run(
+        ["python3", "tools/tracker_sync.py"] + args,
+        cwd=str(REPO_ROOT),
+        capture_output=True, text=True, env=full_env,
+    )
+
+
+class TestCli:
+    def test_update_set_writes_csv(self, tmp_path: Path) -> None:
+        csv_path = tmp_path / "t.csv"
+        result = _run([
+            "--backend", "csv", "--csv-path", str(csv_path),
+            "update", "my-mcp",
+            "--set", "audit_status=Released",
+            "--set", "findings=0",
+            "--set", "production_ready=true",
+            "--set", "released_version=1.2.0",
+        ])
+        assert result.returncode == 0, result.stderr
+        out = json.loads(result.stdout)
+        assert out["ok"] is True
+        assert out["backend"] == "csv"
+        assert out["updated"]["released_version"] == "1.2.0"
+
+        # Direct read-back proves persistence.
+        backend = CsvBackend(csv_path)
+        record = backend.get("my-mcp")
+        assert record.released_version == "1.2.0"
+        assert record.production_ready is True
+
+    def test_update_from_summary(self, tmp_path: Path) -> None:
+        csv_path = tmp_path / "t.csv"
+        summary_path = tmp_path / "summary.json"
+        summary_path.write_text(json.dumps({
+            "audit_meta": {"run_id": "2026-05-09T120000-Z-srv",
+                           "started_at": "2026-05-09T12:00:00Z"},
+            "findings": {"expected_count": 2},
+            "production_ready": False,
+        }), encoding="utf-8")
+
+        result = _run([
+            "--backend", "csv", "--csv-path", str(csv_path),
+            "update", "srv", "--from-summary", str(summary_path),
+        ])
+        assert result.returncode == 0, result.stderr
+
+        backend = CsvBackend(csv_path)
+        record = backend.get("srv")
+        assert record.findings == 2
+        assert record.production_ready is False
+        assert record.last_audit_run == "2026-05-09T120000-Z-srv"
+        assert record.last_audit_at == "2026-05-09"
+
+    def test_get_missing_exits_2(self, tmp_path: Path) -> None:
+        csv_path = tmp_path / "t.csv"
+        result = _run([
+            "--backend", "csv", "--csv-path", str(csv_path),
+            "get", "ghost",
+        ])
+        assert result.returncode == 2
+
+    def test_list_empty(self, tmp_path: Path) -> None:
+        csv_path = tmp_path / "t.csv"
+        result = _run([
+            "--backend", "csv", "--csv-path", str(csv_path),
+            "list",
+        ])
+        assert result.returncode == 0
+        out = json.loads(result.stdout)
+        assert out["count"] == 0
+        assert out["records"] == []
+
+    def test_unknown_field_in_set_fails(self, tmp_path: Path) -> None:
+        csv_path = tmp_path / "t.csv"
+        result = _run([
+            "--backend", "csv", "--csv-path", str(csv_path),
+            "update", "srv", "--set", "bogus_field=x",
+        ])
+        assert result.returncode == 1
+        assert "Unknown field" in result.stderr

--- a/tests/test_tracker_sync.py
+++ b/tests/test_tracker_sync.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 import json
 import os
 import subprocess
+import sys
 from pathlib import Path
 
 import pytest
@@ -163,7 +164,7 @@ def _run(args: list[str], env: dict[str, str] | None = None) -> subprocess.Compl
     if env:
         full_env.update(env)
     return subprocess.run(
-        ["python3", "tools/tracker_sync.py"] + args,
+        [sys.executable, "tools/tracker_sync.py"] + args,
         cwd=str(REPO_ROOT),
         capture_output=True, text=True, env=full_env,
     )

--- a/tools/propose_release.py
+++ b/tools/propose_release.py
@@ -1,0 +1,509 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""propose_release.py — Generate a release proposal for an audited MCP server.
+
+Triggered after an audit + remediation loop reaches `production_ready: true`
+(no failing critical/high findings). The script:
+
+  1. Reads `summary.json` from an audit run and refuses to proceed if the
+     server is not production-ready (or `--force` is passed).
+  2. Detects the current version in the target repo (pyproject.toml,
+     package.json, or latest git tag) and computes the next version using
+     a semver bump (default: patch).
+  3. Generates a CHANGELOG entry that records the audit metadata
+     (skill version, catalog hash, run-id, findings counts) and any
+     user-supplied release notes.
+  4. In `propose` mode (default) prints the diff and the suggested
+     `git tag` / `gh release` commands without touching the working tree.
+  5. In `apply` mode writes the CHANGELOG, creates an annotated git tag,
+     and (if `gh` is available) creates a GitHub release.
+
+The script is intentionally conservative: it never pushes, never force-tags,
+and always shows what it would do unless `--apply` is set. The slash command
+must show the proposal to the user and only call `--apply` after explicit
+confirmation.
+
+Usage:
+    python tools/propose_release.py propose <audit_dir> <target_repo>
+    python tools/propose_release.py apply   <audit_dir> <target_repo> \\
+        --bump minor --notes "Fixes confused-deputy and adds OAuth state."
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from tools.path_utils import force_utf8_stdio  # noqa: E402
+
+SEMVER_RE = re.compile(r"^v?(\d+)\.(\d+)\.(\d+)(?:[-+].*)?$")
+VALID_BUMPS = ("major", "minor", "patch")
+
+
+class ReleaseError(Exception):
+    """Raised on any release-proposal precondition failure."""
+
+
+# ---------------------------------------------------------------------------
+# Summary inspection
+# ---------------------------------------------------------------------------
+
+@dataclass
+class AuditSummary:
+    production_ready: bool
+    blocking_findings: list[str]
+    by_status: dict[str, int]
+    by_severity: dict[str, int]
+    server_name: str
+    run_id: str
+    skill_version: str
+    catalog_hash: str
+    started_at: str
+    findings_count: int
+
+    @classmethod
+    def from_dir(cls, audit_dir: Path) -> "AuditSummary":
+        summary_path = audit_dir / "summary.json"
+        meta_path = audit_dir / "audit-meta.json"
+        if not summary_path.exists():
+            raise ReleaseError(
+                f"summary.json not found at {summary_path}. "
+                "Run `tools/aggregate_results.py aggregate` first."
+            )
+        summary = json.loads(summary_path.read_text(encoding="utf-8"))
+        meta: dict[str, Any] = {}
+        if meta_path.exists():
+            meta = json.loads(meta_path.read_text(encoding="utf-8"))
+
+        audit_meta = summary.get("audit_meta", {}) or {}
+        # Prefer audit-meta.json (richer) over inline audit_meta in summary.
+        merged = {**audit_meta, **meta}
+
+        return cls(
+            production_ready=bool(summary.get("production_ready", False)),
+            blocking_findings=list(summary.get("blocking_findings", [])),
+            by_status=dict(summary.get("totals", {}).get("by_status", {})),
+            by_severity=dict(
+                summary.get("totals", {}).get("by_severity_among_findings", {})
+            ),
+            server_name=str(merged.get("server_name", "")),
+            run_id=str(merged.get("run_id", "")),
+            skill_version=str(merged.get("skill_version", "")),
+            catalog_hash=str(merged.get("catalog_hash", "")),
+            started_at=str(merged.get("started_at", "")),
+            findings_count=int(summary.get("findings", {}).get("expected_count", 0)),
+        )
+
+
+# ---------------------------------------------------------------------------
+# Version detection
+# ---------------------------------------------------------------------------
+
+def detect_current_version(target_repo: Path) -> tuple[str, str]:
+    """Returns (version, source). Source is one of pyproject/package/git/none.
+
+    Resolution order:
+      1. pyproject.toml [project] version
+      2. package.json "version"
+      3. Latest semver-shaped git tag
+      4. ("0.0.0", "none") — caller must decide initial version explicitly
+    """
+    pyproject = target_repo / "pyproject.toml"
+    if pyproject.exists():
+        text = pyproject.read_text(encoding="utf-8")
+        # Minimal parser: avoid pulling tomllib/tomli to keep stdlib-only.
+        # Match `version = "x.y.z"` inside [project] section.
+        in_project = False
+        for line in text.splitlines():
+            stripped = line.strip()
+            if stripped.startswith("[") and stripped.endswith("]"):
+                in_project = stripped == "[project]"
+                continue
+            if in_project:
+                m = re.match(r'^version\s*=\s*"([^"]+)"\s*$', stripped)
+                if m:
+                    return m.group(1), "pyproject"
+
+    package_json = target_repo / "package.json"
+    if package_json.exists():
+        try:
+            pkg = json.loads(package_json.read_text(encoding="utf-8"))
+            v = pkg.get("version")
+            if isinstance(v, str) and v:
+                return v, "package"
+        except json.JSONDecodeError:
+            pass
+
+    # Git tag fallback.
+    try:
+        out = subprocess.run(
+            ["git", "-C", str(target_repo), "tag", "--list", "--sort=-v:refname"],
+            capture_output=True, text=True, check=True,
+        )
+        for tag in out.stdout.splitlines():
+            tag = tag.strip()
+            if SEMVER_RE.match(tag):
+                # Strip leading 'v' if present so callers get pure semver.
+                return tag.lstrip("v"), "git"
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        pass
+
+    return "0.0.0", "none"
+
+
+def bump_version(current: str, bump: str) -> str:
+    if bump not in VALID_BUMPS:
+        raise ReleaseError(f"Invalid bump {bump!r}; valid: {VALID_BUMPS}")
+    m = SEMVER_RE.match(current)
+    if not m:
+        raise ReleaseError(
+            f"Current version {current!r} is not semver-shaped. "
+            "Pass --next-version explicitly to override."
+        )
+    major, minor, patch = (int(x) for x in m.groups()[:3])
+    if bump == "major":
+        return f"{major + 1}.0.0"
+    if bump == "minor":
+        return f"{major}.{minor + 1}.0"
+    return f"{major}.{minor}.{patch + 1}"
+
+
+# ---------------------------------------------------------------------------
+# CHANGELOG generation
+# ---------------------------------------------------------------------------
+
+def render_changelog_entry(
+    version: str,
+    summary: AuditSummary,
+    notes: str | None,
+    today: str,
+) -> str:
+    """Returns the markdown block for a new release entry."""
+    lines: list[str] = []
+    lines.append(f"## [v{version}] — {today}")
+    lines.append("")
+    if notes:
+        lines.append(notes.rstrip())
+        lines.append("")
+
+    lines.append("### Audit verification")
+    lines.append("")
+    lines.append(
+        f"- **Production-ready:** "
+        f"{'✅ yes' if summary.production_ready else '❌ no'}"
+    )
+    if summary.run_id:
+        lines.append(f"- **Audit run-id:** `{summary.run_id}`")
+    if summary.skill_version:
+        lines.append(f"- **Skill version:** `{summary.skill_version}`")
+    if summary.catalog_hash:
+        # Show only first 12 chars; full hash is in audit-meta.json.
+        lines.append(f"- **Catalog hash:** `{summary.catalog_hash[:12]}…`")
+
+    by_status = summary.by_status
+    pass_n = by_status.get("pass", 0)
+    fail_n = by_status.get("fail", 0)
+    partial_n = by_status.get("partial", 0)
+    todo_n = by_status.get("todo", 0)
+    lines.append(
+        f"- **Check results:** {pass_n} pass · {fail_n} fail · "
+        f"{partial_n} partial · {todo_n} todo"
+    )
+    if summary.blocking_findings:
+        joined = ", ".join(summary.blocking_findings)
+        lines.append(f"- **Open blocking findings:** {joined}")
+    lines.append("")
+    return "\n".join(lines) + "\n"
+
+
+def insert_changelog_entry(
+    changelog_path: Path,
+    entry_md: str,
+) -> tuple[str, str]:
+    """Returns (new_text, original_text). Does not write the file.
+
+    Insertion strategy:
+      - If the file doesn't exist: write a minimal Keep-a-Changelog header
+        plus the new entry.
+      - If it has an `## [Unreleased]` block: insert the new entry right
+        after that block, preserving Unreleased.
+      - Otherwise: insert at the top, after the first non-heading line.
+    """
+    if not changelog_path.exists():
+        header = (
+            "# Changelog\n\n"
+            "All notable changes to this project are documented here.\n"
+            "Format: [Keep a Changelog](https://keepachangelog.com/).\n\n"
+        )
+        return header + entry_md, ""
+
+    original = changelog_path.read_text(encoding="utf-8")
+    unreleased = re.search(
+        r"^## \[Unreleased\][^\n]*\n", original, re.MULTILINE,
+    )
+    if unreleased:
+        # Insert before the next `## [` heading.
+        start = unreleased.end()
+        next_release = re.search(r"^## \[", original[start:], re.MULTILINE)
+        if next_release:
+            insertion_at = start + next_release.start()
+        else:
+            insertion_at = len(original)
+        new_text = (
+            original[:insertion_at]
+            + ("\n" if not original[:insertion_at].endswith("\n\n") else "")
+            + entry_md
+            + ("\n" if not entry_md.endswith("\n\n") else "")
+            + original[insertion_at:]
+        )
+        return new_text, original
+
+    # No Unreleased: prepend after the H1, if any.
+    h1 = re.match(r"^# [^\n]*\n+", original)
+    if h1:
+        return original[: h1.end()] + entry_md + "\n" + original[h1.end():], original
+    return entry_md + "\n" + original, original
+
+
+# ---------------------------------------------------------------------------
+# Apply mode — git + gh
+# ---------------------------------------------------------------------------
+
+def run(cmd: list[str], cwd: Path | None = None) -> subprocess.CompletedProcess:
+    return subprocess.run(cmd, cwd=str(cwd) if cwd else None, check=True,
+                          capture_output=True, text=True)
+
+
+def has_gh_cli() -> bool:
+    return shutil.which("gh") is not None
+
+
+def apply_release(
+    target_repo: Path,
+    version: str,
+    changelog_path: Path,
+    new_changelog_text: str,
+    summary: AuditSummary,
+    notes: str | None,
+    create_github_release: bool,
+) -> dict[str, Any]:
+    """Writes CHANGELOG, commits, tags, optionally creates a GH release.
+
+    Never pushes. Returns a dict describing what was done so the caller can
+    print it to the user.
+    """
+    actions: dict[str, Any] = {}
+
+    changelog_path.write_text(new_changelog_text, encoding="utf-8")
+    actions["changelog_written"] = str(changelog_path)
+
+    # Stage + commit only the changelog. Other working-tree changes are
+    # ignored on purpose — releases are explicit, not silent batch-commits.
+    rel = changelog_path.relative_to(target_repo)
+    run(["git", "add", str(rel)], cwd=target_repo)
+    commit_msg = f"chore(release): v{version}\n\nAudit run: {summary.run_id}"
+    try:
+        run(["git", "commit", "-m", commit_msg], cwd=target_repo)
+        actions["committed"] = True
+    except subprocess.CalledProcessError as e:
+        # If nothing was staged (e.g. CHANGELOG already had this entry),
+        # surface that but continue — the tag is still useful.
+        actions["committed"] = False
+        actions["commit_error"] = e.stderr.strip() or e.stdout.strip()
+
+    tag = f"v{version}"
+    tag_msg = f"Release {tag} — audit-verified production-ready"
+    run(["git", "tag", "-a", tag, "-m", tag_msg], cwd=target_repo)
+    actions["tag_created"] = tag
+
+    if create_github_release:
+        if has_gh_cli():
+            release_notes = notes or f"Audit-verified release. Run-ID: {summary.run_id}"
+            run([
+                "gh", "release", "create", tag,
+                "--title", f"Release {tag}",
+                "--notes", release_notes,
+                "--draft",
+            ], cwd=target_repo)
+            actions["github_release"] = "draft"
+        else:
+            actions["github_release"] = "skipped (gh CLI not available)"
+
+    actions["next_steps"] = [
+        f"git -C {target_repo} push origin HEAD",
+        f"git -C {target_repo} push origin {tag}",
+        "Review and publish the draft GitHub release",
+    ]
+    return actions
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+def cmd_propose(args: argparse.Namespace) -> int:
+    audit_dir = Path(args.audit_dir).resolve()
+    target_repo = Path(args.target_repo).resolve()
+
+    summary = AuditSummary.from_dir(audit_dir)
+
+    if not summary.production_ready and not args.force:
+        print(json.dumps({
+            "ok": False,
+            "reason": "not_production_ready",
+            "blocking_findings": summary.blocking_findings,
+            "by_status": summary.by_status,
+            "hint": "Fix the blocking findings or pass --force to override.",
+        }, indent=2, ensure_ascii=False))
+        return 2
+
+    current_version, source = detect_current_version(target_repo)
+    next_version = args.next_version or bump_version(current_version, args.bump)
+    today = (
+        args.today
+        or datetime.now(timezone.utc).date().isoformat()
+    )
+
+    entry = render_changelog_entry(next_version, summary, args.notes, today)
+    changelog = target_repo / args.changelog
+    new_text, _ = insert_changelog_entry(changelog, entry)
+
+    proposal = {
+        "ok": True,
+        "production_ready": summary.production_ready,
+        "current_version": current_version,
+        "current_version_source": source,
+        "next_version": next_version,
+        "bump": args.bump if not args.next_version else "explicit",
+        "changelog_path": str(changelog),
+        "changelog_entry": entry,
+        "tag_command": f"git tag -a v{next_version} -m \"Release v{next_version}\"",
+        "release_command": (
+            f"gh release create v{next_version} --title \"Release v{next_version}\" "
+            f"--notes-file <path> --draft"
+        ),
+        "audit": {
+            "run_id": summary.run_id,
+            "skill_version": summary.skill_version,
+            "catalog_hash_short": summary.catalog_hash[:12],
+            "by_status": summary.by_status,
+            "findings_count": summary.findings_count,
+        },
+    }
+    if args.format == "json":
+        print(json.dumps(proposal, indent=2, ensure_ascii=False))
+    else:
+        print(f"Release proposal for {summary.server_name or target_repo.name}")
+        print(f"  Current version : {current_version} (from {source})")
+        print(f"  Next version    : {next_version}")
+        print(f"  Audit run       : {summary.run_id}")
+        print(f"  CHANGELOG path  : {changelog}")
+        print()
+        print("--- proposed CHANGELOG entry ---")
+        print(entry)
+        print("--- end entry ---")
+        print()
+        print("To apply, re-run with `apply` and the same flags.")
+    return 0
+
+
+def cmd_apply(args: argparse.Namespace) -> int:
+    audit_dir = Path(args.audit_dir).resolve()
+    target_repo = Path(args.target_repo).resolve()
+
+    summary = AuditSummary.from_dir(audit_dir)
+    if not summary.production_ready and not args.force:
+        print(json.dumps({
+            "ok": False,
+            "reason": "not_production_ready",
+            "blocking_findings": summary.blocking_findings,
+        }, indent=2, ensure_ascii=False))
+        return 2
+
+    current_version, source = detect_current_version(target_repo)
+    next_version = args.next_version or bump_version(current_version, args.bump)
+    today = (
+        args.today
+        or datetime.now(timezone.utc).date().isoformat()
+    )
+
+    entry = render_changelog_entry(next_version, summary, args.notes, today)
+    changelog = target_repo / args.changelog
+    new_text, _ = insert_changelog_entry(changelog, entry)
+
+    actions = apply_release(
+        target_repo=target_repo,
+        version=next_version,
+        changelog_path=changelog,
+        new_changelog_text=new_text,
+        summary=summary,
+        notes=args.notes,
+        create_github_release=args.gh_release,
+    )
+    print(json.dumps({
+        "ok": True,
+        "version": next_version,
+        "current_version": current_version,
+        "actions": actions,
+    }, indent=2, ensure_ascii=False))
+    return 0
+
+
+def main() -> None:
+    force_utf8_stdio()
+    parser = argparse.ArgumentParser(
+        prog="propose_release",
+        description=(
+            "Generate a release proposal for an audited MCP server, "
+            "optionally apply it (CHANGELOG + git tag + draft GH release)."
+        ),
+    )
+    sub = parser.add_subparsers(dest="cmd", required=True)
+
+    def _common(p: argparse.ArgumentParser) -> None:
+        p.add_argument("audit_dir", help="Path to the audit run dir (contains summary.json).")
+        p.add_argument("target_repo", help="Path to the audited server's git repo.")
+        p.add_argument("--bump", choices=VALID_BUMPS, default="patch",
+                       help="Semver bump (default: patch).")
+        p.add_argument("--next-version", help="Explicit version, overrides --bump.")
+        p.add_argument("--changelog", default="CHANGELOG.md",
+                       help="CHANGELOG file relative to target_repo.")
+        p.add_argument("--notes", help="Free-form release notes (markdown).")
+        p.add_argument("--today", help="Override release date (YYYY-MM-DD); for tests.")
+        p.add_argument("--force", action="store_true",
+                       help="Allow release even if not production_ready.")
+
+    sp = sub.add_parser("propose", help="Print proposal, do not modify anything.")
+    _common(sp)
+    sp.add_argument("--format", choices=("text", "json"), default="text")
+    sp.set_defaults(func=cmd_propose)
+
+    sp = sub.add_parser("apply", help="Write CHANGELOG, commit, tag, draft GH release.")
+    _common(sp)
+    sp.add_argument("--gh-release", action="store_true",
+                    help="Also create a draft GitHub release via gh CLI.")
+    sp.set_defaults(func=cmd_apply)
+
+    args = parser.parse_args()
+    try:
+        sys.exit(args.func(args))
+    except ReleaseError as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/tracker_sync.py
+++ b/tools/tracker_sync.py
@@ -1,0 +1,483 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""tracker_sync.py — Pluggable audit-tracker backend.
+
+The Notion-only `audit-notion-sync.py` worked for the original Stadt-Zürich
+setup but blocks anyone who tracks their MCP-server portfolio elsewhere.
+This module replaces that with a backend abstraction so the same skill
+can drive Notion, a local CSV file, or future backends (Airtable, Google
+Sheets) — same `update`/`get` interface, same field semantics.
+
+Field schema (canonical, backend-agnostic):
+
+    server_name      str   primary key
+    audit_status     str   one of: Triagiert / In Audit /
+                            Findings dokumentiert / In Remediation /
+                            Abgeschlossen / Released
+    findings         int   total findings count from summary.json
+    last_audit_run   str   run-id (ISO timestamp + offset + slug)
+    last_audit_at    str   ISO date of the audit run
+    production_ready bool  pulled from summary.json
+    released_version str   set after `propose_release apply` succeeds
+    notes            str   free-form, append-only
+
+Backends implement these via a small adapter class; the CLI dispatches
+on `--backend` (or env var `MCP_AUDIT_TRACKER_BACKEND`).
+
+Stdlib only — no extra deps for the CSV backend; Notion uses the same
+urllib pattern as `audit-notion-sync.py`.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import os
+import sys
+from dataclasses import dataclass, asdict
+from pathlib import Path
+from typing import Any, Iterable
+from urllib.error import HTTPError, URLError
+from urllib.request import Request, urlopen
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from tools.path_utils import force_utf8_stdio  # noqa: E402
+
+CANONICAL_FIELDS = (
+    "server_name",
+    "audit_status",
+    "findings",
+    "last_audit_run",
+    "last_audit_at",
+    "production_ready",
+    "released_version",
+    "notes",
+)
+
+
+class TrackerError(Exception):
+    """Raised on backend connectivity, auth, or schema errors."""
+
+
+@dataclass
+class TrackerRecord:
+    server_name: str
+    audit_status: str | None = None
+    findings: int | None = None
+    last_audit_run: str | None = None
+    last_audit_at: str | None = None
+    production_ready: bool | None = None
+    released_version: str | None = None
+    notes: str | None = None
+
+    def to_dict_nonnull(self) -> dict[str, Any]:
+        return {k: v for k, v in asdict(self).items() if v is not None}
+
+
+# ---------------------------------------------------------------------------
+# Backend interface
+# ---------------------------------------------------------------------------
+
+class TrackerBackend:
+    name: str = "abstract"
+
+    def get(self, server_name: str) -> TrackerRecord | None:
+        raise NotImplementedError
+
+    def update(self, server_name: str, fields: dict[str, Any]) -> TrackerRecord:
+        raise NotImplementedError
+
+    def list_all(self) -> list[TrackerRecord]:
+        raise NotImplementedError
+
+
+# ---------------------------------------------------------------------------
+# CSV backend — zero-deps, perfect for users without any cloud DB.
+# ---------------------------------------------------------------------------
+
+class CsvBackend(TrackerBackend):
+    name = "csv"
+
+    def __init__(self, path: Path):
+        self.path = Path(path)
+
+    def _ensure_file(self) -> None:
+        if not self.path.exists():
+            self.path.parent.mkdir(parents=True, exist_ok=True)
+            with self.path.open("w", encoding="utf-8", newline="") as f:
+                w = csv.DictWriter(f, fieldnames=CANONICAL_FIELDS)
+                w.writeheader()
+
+    def _read_rows(self) -> list[dict[str, str]]:
+        self._ensure_file()
+        with self.path.open("r", encoding="utf-8", newline="") as f:
+            return list(csv.DictReader(f))
+
+    def _write_rows(self, rows: Iterable[dict[str, str]]) -> None:
+        with self.path.open("w", encoding="utf-8", newline="") as f:
+            w = csv.DictWriter(f, fieldnames=CANONICAL_FIELDS)
+            w.writeheader()
+            for row in rows:
+                # Coerce all values to strings so CSV stays valid.
+                w.writerow({k: ("" if row.get(k) is None else str(row.get(k)))
+                            for k in CANONICAL_FIELDS})
+
+    @staticmethod
+    def _row_to_record(row: dict[str, str]) -> TrackerRecord:
+        def _opt(v: str) -> str | None:
+            return v if v != "" else None
+
+        findings = row.get("findings", "") or ""
+        prod_ready = row.get("production_ready", "") or ""
+        return TrackerRecord(
+            server_name=row.get("server_name", ""),
+            audit_status=_opt(row.get("audit_status", "")),
+            findings=int(findings) if findings.strip().isdigit() else None,
+            last_audit_run=_opt(row.get("last_audit_run", "")),
+            last_audit_at=_opt(row.get("last_audit_at", "")),
+            production_ready=(
+                None if prod_ready == "" else prod_ready.lower() == "true"
+            ),
+            released_version=_opt(row.get("released_version", "")),
+            notes=_opt(row.get("notes", "")),
+        )
+
+    def get(self, server_name: str) -> TrackerRecord | None:
+        for row in self._read_rows():
+            if row.get("server_name") == server_name:
+                return self._row_to_record(row)
+        return None
+
+    def update(self, server_name: str, fields: dict[str, Any]) -> TrackerRecord:
+        rows = self._read_rows()
+        merged: dict[str, Any] = {"server_name": server_name}
+        found_index: int | None = None
+        for i, row in enumerate(rows):
+            if row.get("server_name") == server_name:
+                merged = {**row, "server_name": server_name}
+                found_index = i
+                break
+
+        for k, v in fields.items():
+            if k not in CANONICAL_FIELDS:
+                raise TrackerError(
+                    f"Unknown field {k!r}; valid: {CANONICAL_FIELDS}"
+                )
+            merged[k] = v
+
+        if found_index is None:
+            rows.append(merged)
+        else:
+            rows[found_index] = merged
+
+        self._write_rows(rows)
+        return self._row_to_record(
+            {k: ("" if merged.get(k) is None else str(merged.get(k)))
+             for k in CANONICAL_FIELDS}
+        )
+
+    def list_all(self) -> list[TrackerRecord]:
+        return [self._row_to_record(r) for r in self._read_rows()]
+
+
+# ---------------------------------------------------------------------------
+# Notion backend — wraps the same API the existing audit-notion-sync uses.
+# ---------------------------------------------------------------------------
+
+NOTION_API = "https://api.notion.com/v1"
+NOTION_VERSION = "2022-06-28"
+NOTION_DEFAULT_DB_ID = "a2736a65-677d-4cf3-9f94-e874f74a1975"
+
+
+class NotionBackend(TrackerBackend):
+    name = "notion"
+
+    # Map canonical field → (notion property name, notion property type).
+    # Properties not present in this map fall through to "Notizen" rich-text.
+    FIELD_MAP: dict[str, tuple[str, str]] = {
+        "audit_status": ("Audit-Status", "select"),
+        "findings": ("Findings", "number"),
+        "released_version": ("Released Version", "rich_text"),
+        "last_audit_run": ("Last Audit Run", "rich_text"),
+        "last_audit_at": ("Last Audit At", "rich_text"),
+        "production_ready": ("Production Ready", "checkbox"),
+    }
+
+    def __init__(self, token: str, db_id: str):
+        self.token = token
+        self.db_id = db_id
+
+    @classmethod
+    def from_env(cls) -> "NotionBackend":
+        token = os.environ.get("NOTION_TOKEN")
+        if not token:
+            raise TrackerError(
+                "NOTION_TOKEN env var not set; required for the notion backend."
+            )
+        db_id = os.environ.get("NOTION_AUDIT_DB_ID", NOTION_DEFAULT_DB_ID)
+        return cls(token=token, db_id=db_id)
+
+    def _request(self, method: str, path: str, body: dict[str, Any] | None = None) -> dict[str, Any]:
+        url = f"{NOTION_API}{path}"
+        data = json.dumps(body).encode("utf-8") if body is not None else None
+        req = Request(url, data=data, method=method)
+        req.add_header("Authorization", f"Bearer {self.token}")
+        req.add_header("Notion-Version", NOTION_VERSION)
+        if data is not None:
+            req.add_header("Content-Type", "application/json")
+        try:
+            with urlopen(req) as resp:
+                return json.loads(resp.read().decode("utf-8"))
+        except HTTPError as e:
+            try:
+                err = json.loads(e.read().decode("utf-8"))
+                msg = err.get("message", str(e))
+            except Exception:
+                msg = str(e)
+            raise TrackerError(f"Notion API {e.code}: {msg} [{method} {path}]")
+        except URLError as e:
+            raise TrackerError(f"Notion network error: {e.reason}")
+
+    def _find_page_id(self, server_name: str) -> str | None:
+        body = {
+            "filter": {
+                "property": "Server Name",
+                "title": {"equals": server_name},
+            },
+            "page_size": 2,
+        }
+        resp = self._request("POST", f"/databases/{self.db_id}/query", body)
+        results = resp.get("results", [])
+        if not results:
+            return None
+        if len(results) > 1:
+            raise TrackerError(
+                f"Multiple Notion pages match Server Name={server_name!r}."
+            )
+        return results[0]["id"]
+
+    @staticmethod
+    def _build_property(notion_type: str, value: Any) -> dict[str, Any]:
+        if notion_type == "select":
+            return {"select": {"name": str(value)}}
+        if notion_type == "number":
+            return {"number": value}
+        if notion_type == "checkbox":
+            return {"checkbox": bool(value)}
+        if notion_type == "rich_text":
+            return {
+                "rich_text": [{"type": "text", "text": {"content": str(value)}}]
+            }
+        raise TrackerError(f"Unsupported Notion property type {notion_type!r}")
+
+    def update(self, server_name: str, fields: dict[str, Any]) -> TrackerRecord:
+        page_id = self._find_page_id(server_name)
+        if not page_id:
+            raise TrackerError(
+                f"No Notion page for Server Name={server_name!r}. "
+                "Create the tracker entry first."
+            )
+
+        properties: dict[str, Any] = {}
+        notes_extra: list[str] = []
+        for k, v in fields.items():
+            if k not in CANONICAL_FIELDS:
+                raise TrackerError(f"Unknown field {k!r}")
+            if k == "server_name":
+                continue
+            if k in self.FIELD_MAP:
+                prop_name, prop_type = self.FIELD_MAP[k]
+                properties[prop_name] = self._build_property(prop_type, v)
+            elif k == "notes":
+                notes_extra.append(str(v))
+
+        if notes_extra:
+            properties["Notizen"] = {
+                "rich_text": [
+                    {"type": "text", "text": {"content": "\n".join(notes_extra)}}
+                ],
+            }
+
+        if not properties:
+            raise TrackerError("Nothing to update — no mapped fields.")
+
+        self._request("PATCH", f"/pages/{page_id}", {"properties": properties})
+        # We don't round-trip the full record here; return what we wrote.
+        record = TrackerRecord(server_name=server_name)
+        for k, v in fields.items():
+            setattr(record, k, v)
+        return record
+
+    def get(self, server_name: str) -> TrackerRecord | None:
+        page_id = self._find_page_id(server_name)
+        if not page_id:
+            return None
+        # Minimal projection: only re-derive the fields we know how to read
+        # back. Reading back is rarely needed; existing portfolio.yaml flow
+        # remains the authoritative pull path.
+        return TrackerRecord(server_name=server_name)
+
+    def list_all(self) -> list[TrackerRecord]:
+        pages: list[dict[str, Any]] = []
+        cursor: str | None = None
+        while True:
+            body: dict[str, Any] = {"page_size": 100}
+            if cursor:
+                body["start_cursor"] = cursor
+            resp = self._request("POST", f"/databases/{self.db_id}/query", body)
+            pages.extend(resp.get("results", []))
+            if not resp.get("has_more"):
+                break
+            cursor = resp.get("next_cursor")
+        records: list[TrackerRecord] = []
+        for p in pages:
+            props = p.get("properties", {})
+            title = props.get("Server Name", {}).get("title", [])
+            name = "".join(t.get("plain_text", "") for t in title).strip()
+            if name:
+                records.append(TrackerRecord(server_name=name))
+        return records
+
+
+# ---------------------------------------------------------------------------
+# Backend resolver
+# ---------------------------------------------------------------------------
+
+def get_backend(name: str | None, csv_path: str | None = None) -> TrackerBackend:
+    backend = (name or os.environ.get("MCP_AUDIT_TRACKER_BACKEND") or "csv").lower()
+    if backend == "csv":
+        path = csv_path or os.environ.get("MCP_AUDIT_TRACKER_PATH") or "tracker.csv"
+        return CsvBackend(Path(path))
+    if backend == "notion":
+        return NotionBackend.from_env()
+    raise TrackerError(
+        f"Unknown tracker backend {backend!r}; valid: csv, notion"
+    )
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+def _parse_kv(items: list[str]) -> dict[str, Any]:
+    """Parse `key=value` flags into a typed dict."""
+    out: dict[str, Any] = {}
+    for item in items:
+        if "=" not in item:
+            raise TrackerError(f"Bad --set value {item!r}, expected key=value")
+        k, v = item.split("=", 1)
+        if k not in CANONICAL_FIELDS:
+            raise TrackerError(f"Unknown field {k!r}")
+        if k == "findings":
+            out[k] = int(v)
+        elif k == "production_ready":
+            out[k] = v.lower() in ("true", "1", "yes")
+        else:
+            out[k] = v
+    return out
+
+
+def cmd_update(args: argparse.Namespace) -> int:
+    backend = get_backend(args.backend, args.csv_path)
+    fields = _parse_kv(args.set or [])
+
+    # Convenience: if --from-summary is given, pull common fields from a
+    # summary.json so callers don't have to duplicate them on the CLI.
+    if args.from_summary:
+        summary = json.loads(Path(args.from_summary).read_text(encoding="utf-8"))
+        fields.setdefault(
+            "findings",
+            int(summary.get("findings", {}).get("expected_count", 0)),
+        )
+        fields.setdefault(
+            "production_ready",
+            bool(summary.get("production_ready", False)),
+        )
+        meta = summary.get("audit_meta", {}) or {}
+        if meta.get("run_id"):
+            fields.setdefault("last_audit_run", meta["run_id"])
+        if meta.get("started_at"):
+            fields.setdefault("last_audit_at", str(meta["started_at"])[:10])
+
+    if not fields:
+        raise TrackerError("Nothing to update; pass --set key=value or --from-summary.")
+
+    record = backend.update(args.server, fields)
+    print(json.dumps({
+        "ok": True,
+        "backend": backend.name,
+        "server_name": record.server_name,
+        "updated": record.to_dict_nonnull(),
+    }, indent=2, ensure_ascii=False))
+    return 0
+
+
+def cmd_get(args: argparse.Namespace) -> int:
+    backend = get_backend(args.backend, args.csv_path)
+    record = backend.get(args.server)
+    if record is None:
+        print(json.dumps({"ok": False, "reason": "not_found",
+                          "backend": backend.name}, indent=2))
+        return 2
+    print(json.dumps({"ok": True, "backend": backend.name,
+                      "record": record.to_dict_nonnull()},
+                     indent=2, ensure_ascii=False))
+    return 0
+
+
+def cmd_list(args: argparse.Namespace) -> int:
+    backend = get_backend(args.backend, args.csv_path)
+    records = backend.list_all()
+    print(json.dumps({
+        "ok": True,
+        "backend": backend.name,
+        "count": len(records),
+        "records": [r.to_dict_nonnull() for r in records],
+    }, indent=2, ensure_ascii=False))
+    return 0
+
+
+def main() -> None:
+    force_utf8_stdio()
+    parser = argparse.ArgumentParser(
+        prog="tracker_sync",
+        description="Update an audit-tracker record across pluggable backends.",
+    )
+    parser.add_argument(
+        "--backend", choices=("csv", "notion"),
+        help="Override $MCP_AUDIT_TRACKER_BACKEND. Default: csv.",
+    )
+    parser.add_argument(
+        "--csv-path",
+        help="CSV file path (csv backend). Override $MCP_AUDIT_TRACKER_PATH.",
+    )
+    sub = parser.add_subparsers(dest="cmd", required=True)
+
+    sp = sub.add_parser("update", help="Set fields on a server's row.")
+    sp.add_argument("server", help="Server name (primary key).")
+    sp.add_argument("--set", action="append", metavar="key=value",
+                    help="Repeatable. Valid keys: " + ", ".join(CANONICAL_FIELDS))
+    sp.add_argument("--from-summary", help="Pull defaults from a summary.json.")
+    sp.set_defaults(func=cmd_update)
+
+    sp = sub.add_parser("get", help="Read a single record.")
+    sp.add_argument("server")
+    sp.set_defaults(func=cmd_get)
+
+    sp = sub.add_parser("list", help="List all records.")
+    sp.set_defaults(func=cmd_list)
+
+    args = parser.parse_args()
+    try:
+        sys.exit(args.func(args))
+    except TrackerError as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Zwei Verbesserungen am Skill, ausgelöst durch deine Anfrage:

1. **Schritt 7 — Release-Vorschlag (für den auditierten Server, nicht das Skill-Repo).** Wenn `summary.json` `production_ready: true` zeigt, schlägt der Skill einen versionierten Release vor: semver-Bump aus `pyproject.toml` / `package.json` / git-Tag, generierter CHANGELOG-Eintrag mit Audit-Metadaten (run-id, catalog hash, by_status) und vorgeschlagene `git tag` / `gh release`-Befehle. Im `apply`-Modus schreibt das Tool den CHANGELOG, committet, erzeugt einen annotated git tag und optional einen `gh release --draft`. **Pusht niemals automatisch** und ändert **keine Versions-Strings** in den Manifesten — das bleibt Maintainer-Verantwortung.

2. **Pluggable Tracker-Backends.** Der bisherige `audit-notion-sync.py` band den Skill an Notion. Neu: `tools/tracker_sync.py` mit `TrackerBackend.get/update/list_all`-Interface. Adapter heute: `csv` (zero-deps, Default — perfekt für User ohne Cloud-DB) und `notion`. Backend-Wahl via `--backend` oder `MCP_AUDIT_TRACKER_BACKEND`. `--from-summary` zieht `findings`, `production_ready` und `run-id` direkt aus `summary.json` (Single-Source-of-Truth, kein Re-Counting). Weitere Adapter (Airtable, Google Sheets) lassen sich durch eine kleine Klasse hinzufügen — Interface ist dokumentiert.

### Files

- **Neu:** `tools/propose_release.py`, `tools/tracker_sync.py`
- **Neu:** `tests/test_propose_release.py` (23 cases), `tests/test_tracker_sync.py` (19 cases)
- **Geändert:** `SKILL.md` (Step 5.2 + neuer Step 7), `.claude/commands/audit-mcp.md` (neuer Step 7), `CHANGELOG.md` (Unreleased-Block)

### Sicherheits-Verhalten

- `propose_release.py` weigert sich bei `production_ready: false` (exit 2). `--force` existiert für dokumentierte Hotfix-Eskalationen.
- Apply-Modus ist defensiv: kein `git push`, GH-Release immer als Draft.
- Slash-Command Schritt 7 dokumentiert: Apply nur nach **explizitem User-OK**, niemals stillschweigend.

## Test plan

- [x] `pytest -q` — 297 passed (255 → 297, +42 neue Cases)
- [x] `propose` ohne production_ready → exit 2 mit `blocking_findings`
- [x] `propose` mit production_ready → CHANGELOG-Diff, Working Tree unverändert
- [x] CSV-Backend Round-Trip (insert / partial update / list_all / bool round-trip)
- [x] `tracker_sync update --from-summary` zieht Felder korrekt aus summary.json
- [x] Backend-Resolver: Default csv, ENV-Override, unknown backend → Fehler
- [ ] End-to-end auf einem echten Server-Repo (manueller Smoke-Test durch dich)
- [ ] Notion-Backend gegen echten Workspace (braucht `NOTION_TOKEN`)

https://claude.ai/code/session_01FGHUtURp15M6yD3hA3n3US

---
_Generated by [Claude Code](https://claude.ai/code/session_01FGHUtURp15M6yD3hA3n3US)_